### PR TITLE
WIP: added private fork of awkward to the pip requirements

### DIFF
--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -2,5 +2,6 @@
 
 pyarrow==6.0.*
 coffea==0.7.*
-uproot==4.2.*
-awkward==1.8.*
+uproot==4.2.3
+# awkward==1.8.*
+git+https://github.com/uhh-cms/awkward.git


### PR DESCRIPTION
I'm opening a draft pull request now, so we can decide how to move on.

The underlying issue is #38 . Currently, awkward only supports loading top-level fields (e.g. `Jets`). I have been investigating the possibility of broading the functionailities of the underlying awkward code, for which we forked the awkward repository to [the group github space](https://github.com/uhh-cms/awkward). The current version of the fork can do what we want: It accepts column names in the form of lists of tuples that represent the underlying structure of the parquet files. For example, in a parquet file with the structure

```mermaid
graph TB;
    A(Jets) --> |child| B(pt);
    A --> |child| C(mass)
```

one could load one of the column e.g. with `[(Jet, pt)]`. This has been verified to work with the branch.

However, there is one issue: There seems to be a bug in Parquet which causes one flag/property of the underlying parquet structure to be not ported properly (whether a `Struct` object can be nullable or not). This inturn results in a "more nested" structure in awkward when we load the parqet files. The same bug was already reported by one of the awkward developers [here](https://issues.apache.org/jira/browse/ARROW-14485) back in October. So far, there has been no answer.

This issue shouldn't really impede our setup - the usability of the resulting array is exactly the same, and we don't really care (as users) whether a field is nullable or not (in this instance, I think). Nevertheless, I decided to ask the developers whether this could affect us somehow downstream. You can find the discussion [here](https://github.com/scikit-hep/awkward/discussions/1522).

They already answered :D Seems like the next version of awkward (`v2`) already supports this. So it might make sense to just use `awkward._v2` instead of `awkward` in the first place to avoid this issue and avoid using a fork without ongoing development 🤔 What do you guys think?

Closes #38 