### PR TITLE
added process_lines parameter to plotting tasks

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -786,6 +786,12 @@ class PlotMixin(AnalysisTask):
         description="string parameter to define the y-axis scale of the plot in the upper panel; "
         "choices: NO_STR,linear,log; no default",
     )
+    process_lines = law.CSVParameter(
+        default=(),
+        description="comma-separated process names or patterns to plot as individual lines; "
+        "can also be the key of a mapping defined in the 'process_groups' auxiliary data of "
+        "the config; uses no process when empty; empty default",
+    )
 
     def get_plot_parameters(self):
         # convert parameters to usable values during plotting
@@ -795,6 +801,7 @@ class PlotMixin(AnalysisTask):
             "skip_legend": self.skip_legend,
             "skip_cms": self.skip_cms,
             "yscale": None if self.y_scale == law.NO_STR else self.y_scale,
+            "process_lines": self.process_lines,
         }
 
     def get_plot_func(self, func_name: str) -> Callable:


### PR DESCRIPTION
This PR adds the `process_lines` parameter to plotting tasks, which removes selected processes from the stack and plots them as individual lines instead.

Example command:
```
law run cf.PlotVariables \                                                                                                                                       
    --version v1 \
    --datasets st_tchannel_t,tt_sl \
    --producers example \
    --variables jet1_pt \
    --categories 1e \
    --branch 0 \
    --process-lines st_tchannel_t
```