### PR TITLE
Add mc_weight producer, favor over lhe weight

### DIFF
--- a/columnflow/example_config/analysis_st.py
+++ b/columnflow/example_config/analysis_st.py
@@ -148,12 +148,10 @@ config_2018.set_aux("keep_columns", DotDict.wrap({
     "cf.ReduceEvents": {
         "run", "luminosityBlock", "event",
         "nJet", "Jet.pt", "Jet.eta", "Jet.btagDeepFlavB",
-        "LHEWeight.originalXWGTUP",
-        "PV.npvs",
-        "category_ids", "deterministic_seed",
+        "mc_weight", "PV.npvs", "category_ids", "deterministic_seed",
     },
     "cf.MergeSelectionMasks": {
-        "LHEWeight.originalXWGTUP", "normalization_weight", "process_id", "category_ids", "cutflow.*",
+        "mc_weight", "normalization_weight", "process_id", "category_ids", "cutflow.*",
     },
 }))
 
@@ -181,10 +179,10 @@ cat_e = config_2018.add_category(
 
 # add variables
 config_2018.add_variable(
-    name="lhe_weight",
-    expression="LHEWeight.originalXWGTUP",
+    name="mc_weight",
+    expression="mc_weight",
     binning=(200, -10, 10),
-    x_title="LHE weight",
+    x_title="MC weight",
 )
 config_2018.add_variable(
     name="ht",

--- a/columnflow/production/mc_weight.py
+++ b/columnflow/production/mc_weight.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+"""
+Methods for dealing with MC weights.
+"""
+
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column, has_ak_column
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@producer(
+    uses={"genWeight", "LHEWeight.originalXWGTUP"},
+    produces={"mc_weight"},
+)
+def mc_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Reads the genWeight and LHEWeight columns and makes a decision about which one to save. This
+    should have been configured centrally [1] and stored in genWeight, but there are some samples
+    where this failed.
+
+    Strategy:
+      1. When LHEWeight is missing, use genWeight.
+      2. When both exist and they are identical, use genWeight.
+      3. When both exist and genWeight is always one, use LHEWeight.
+      4. Raise an exception in all other cases.
+
+    [1] https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD?rev=99#Weigths
+    """
+    # skip real data
+    if self.dataset_inst.is_data:
+        return events
+
+    # determine the mc_weight
+    if not has_ak_column(events, "LHEWeight.originalXWGTUP"):
+        mc_weight = events.genWeight
+    elif ak.all(events.genWeight == events.LHEWeight.originalXWGTUP):
+        mc_weight = events.genWeight
+    elif ak.all(events.genWeight == 1.0):
+        mc_weight = events.LHEWeight.originalXWGTUP
+    else:
+        raise Exception(
+            f"cannot determine mc_weight from genWeight {events.genWeight} and "
+            f"LHEWeight {events.LHEWeight.originalXWGTUP}",
+        )
+
+    # store the column
+    events = set_ak_column(events, "mc_weight", mc_weight)
+
+    return events

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -16,7 +16,7 @@ ak = maybe_import("awkward")
 
 
 @producer(
-    uses={process_ids, "LHEWeight.originalXWGTUP"},
+    uses={process_ids, "mc_weight"},
     produces={process_ids, "normalization_weight"},
 )
 def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
@@ -43,8 +43,8 @@ def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Arra
     sum_weights = np.array(self.sum_weights_table[0, process_id].todense())[0]
 
     # compute the weight and store it
-    norm_weight = events.LHEWeight.originalXWGTUP * lumi * xs / sum_weights
-    set_ak_column(events, "normalization_weight", norm_weight)
+    norm_weight = events.mc_weight * lumi * xs / sum_weights
+    events = set_ak_column(events, "normalization_weight", norm_weight)
 
     return events
 

--- a/columnflow/selection/example.py
+++ b/columnflow/selection/example.py
@@ -88,7 +88,7 @@ def jet_selection_test(
 # combined selectors
 #
 
-@selector(uses={"LHEWeight.originalXWGTUP"})
+@selector(uses={"mc_weight"})
 def increment_stats(
     self: Selector,
     events: ak.Array,
@@ -109,7 +109,7 @@ def increment_stats(
 
     # store sum of event weights for mc events
     if self.dataset_inst.is_mc:
-        weights = events.LHEWeight.originalXWGTUP
+        weights = events.mc_weight
 
         # sum for all processes
         stats["sum_mc_weight"] += ak.sum(weights)
@@ -130,11 +130,9 @@ def increment_stats(
 @selector(
     uses={
         category_ids, jet_selection_test, process_ids, increment_stats, cutflow_features,
-        "LHEWeight.originalXWGTUP",
     },
     produces={
         category_ids, jet_selection_test, process_ids, increment_stats, cutflow_features,
-        "LHEWeight.originalXWGTUP",
     },
     exposed=True,
 )

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -35,7 +35,7 @@ class CreateCutflowHistograms(
 
     selector_steps_order_sensitive = True
 
-    default_variables = ("lhe_weight", "cf_*")
+    default_variables = ("mc_weight", "cf_*")
 
     # default upstream dependency task classes
     dep_MergeSelectionMasks = MergeSelectionMasks
@@ -205,7 +205,7 @@ class PlotCutflow(
             self.dep_CreateCutflowHistograms.req(
                 self,
                 dataset=d,
-                variables=("lhe_weight",),
+                variables=("mc_weight",),
                 _prefer_cli={"variables"},
                 _exclude={"branches"},
             )
@@ -219,7 +219,7 @@ class PlotCutflow(
                 self,
                 branch=0,
                 dataset=d,
-                variables=("lhe_weight",),
+                variables=("mc_weight",),
                 _prefer_cli={"variables"},
             )
             for d in self.datasets
@@ -248,7 +248,7 @@ class PlotCutflow(
         with self.publish_step(f"plotting cutflow in {category_inst.name}"):
             for dataset, inp in self.input().items():
                 dataset_inst = self.config_inst.get_dataset(dataset)
-                h_in = inp["lhe_weight"].load(formatter="pickle")
+                h_in = inp["mc_weight"].load(formatter="pickle")
 
                 # sanity checks
                 n_shifts = len(h_in.axes["shift"])
@@ -279,7 +279,7 @@ class PlotCutflow(
                     }]
 
                     # axis reductions
-                    h = h[{"process": sum, "category": sum, "shift": sum, "lhe_weight": sum}]
+                    h = h[{"process": sum, "category": sum, "shift": sum, "mc_weight": sum}]
 
                     # add the histogram
                     if process_inst in hists:


### PR DESCRIPTION
This PR adds a new producer `mc_weight` which should be used early on during calibration to create a column with the true MC weight to be used throughout the analysis.

### Background

There are multiple columns that might carry generator weight information:

- `genWeight`
- `Generator.weight`
- `LHEWeight.originalXWGTUP`

According to https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD?rev=99#Weigths the two former columns are identical and this seems true in the 5 different datasets I tested. The next *claim* is that `genWeight` is the product of `LHEWeight.originalXWGTUP` and potential additional weights from the generator chain. However, this is not true for all samples. In some madgraph samples (e.g. `hh_ggf_bbtautau_madgraph`) the lhe weight is some O(1e-2) value, while the `genWeight` is always 1.

To be robust against these bugs in MC, I added a producer that makes a selection between the two options, favoring `genWeight` when it's present and not 1, using the LHE otherwise when existing.


### Changes

- Added the producer
- Adjusted the remaining code to use the `mc_weight` column instead of `LHEWeight.originalXWGTUP`

This should be considered in any downstream analysis.