### PR TITLE
Generalize job submission, add SlurmWorkflow

### DIFF
--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -21,8 +21,8 @@ from columnflow.__version__ import (  # noqa
 
 # load contrib packages
 law.contrib.load(
-    "arc", "awkward", "cms", "git", "htcondor", "numpy", "pyarrow", "telegram", "root", "tasks",
-    "wlcg", "matplotlib",
+    "arc", "awkward", "cms", "git", "htcondor", "numpy", "pyarrow", "telegram", "root", "slurm",
+    "tasks", "wlcg", "matplotlib",
 )
 
 # initialize wlcg file systems once so that their cache cleanup is triggered if configured

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1128,7 +1128,8 @@ class ArrayFunction(Derivable):
         # create instance-level sets of dependent ArrayFunction classes,
         # optionally extended by sets passed in keyword arguments
         for attr in self.dependency_sets:
-            deps = getattr(self.__class__, attr) | set(law.util.make_list(kwargs.get(attr) or []))
+            deps = set(law.util.make_list(getattr(self.__class__, attr)))
+            deps |= set(law.util.make_list(kwargs.get(attr) or []))
             setattr(self, attr, deps)
 
         # dictionary of dependency class to instance, set in create_dependencies

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -8,7 +8,7 @@ import law
 
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorMixin
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox
 
@@ -16,7 +16,7 @@ from columnflow.util import maybe_import, ensure_proxy, dev_sandbox
 ak = maybe_import("awkward")
 
 
-class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, HTCondorWorkflow):
+class CalibrateEvents(DatasetTask, CalibratorMixin, law.LocalWorkflow, RemoteWorkflow):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -14,7 +14,7 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, VariablesMixin, PlotMixin,
 )
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.plotting import ProcessPlotBase
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -26,7 +26,7 @@ class CreateCutflowHistograms(
     CalibratorsMixin,
     VariablesMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
@@ -172,7 +172,7 @@ class PlotCutflow(
     CalibratorsMixin,
     ProcessPlotBase,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
@@ -324,7 +324,7 @@ class PlotCutflowVariables(
     VariablesMixin,
     ProcessPlotBase,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     per_plot = luigi.ChoiceParameter(

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -27,7 +27,7 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
 
     def get_repo_path(self):
         # required by BundleGitRepository
-        return os.environ["CF_BASE"]
+        return os.environ["CF_REPO_BASE"]
 
     def single_output(self):
         repo_base = os.path.basename(self.get_repo_path())

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -48,8 +48,10 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
         self.bundle(bundle)
 
         # log the size
-        self.publish_message("bundled repository archive, size is {:.2f} {}".format(
-            *law.util.human_bytes(bundle.stat().st_size)))
+        self.publish_message(
+            "bundled repository archive, size is {:.2f} {}".format(
+                *law.util.human_bytes(bundle.stat().st_size)),
+        )
 
         # transfer the bundle
         self.transfer(bundle)
@@ -120,8 +122,10 @@ class BundleSoftware(AnalysisTask, law.tasks.TransferLocalFile):
         bundle.dump(software_path, filter=_filter, formatter="tar")
 
         # log the size
-        self.publish_message("bundled software archive, size is {:.2f} {}".format(
-            *law.util.human_bytes(bundle.stat().st_size)))
+        self.publish_message(
+            "bundled software archive, size is {:.2f} {}".format(
+                *law.util.human_bytes(bundle.stat().st_size)),
+        )
 
         # transfer the bundle
         self.transfer(bundle)
@@ -176,11 +180,16 @@ class BundleCMSSW(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLocalFile
         self.bundle(bundle)
 
         # log the size
-        self.publish_message("bundled CMSSW archive, size is {:.2f} {}".format(
-            *law.util.human_bytes(bundle.stat().st_size)))
+        self.publish_message(
+            "bundled CMSSW archive, size is {:.2f} {}".format(
+                *law.util.human_bytes(bundle.stat().st_size)),
+        )
 
         # transfer the bundle and mark the task as complete
         self.transfer(bundle)
+
+
+_default_htcondor_flavor = os.getenv("CF_HTCONDOR_FLAVOR", "naf")
 
 
 class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
@@ -203,24 +212,24 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         "empty default",
     )
     htcondor_flavor = luigi.ChoiceParameter(
-        default=os.getenv("CF_HTCONDOR_FLAVOR", "naf"),
-        choices=("naf", "naf"),
+        default=_default_htcondor_flavor,
+        choices=("naf", "cern"),
         significant=False,
         description="the 'flavor' (i.e. configuration name) of the batch system; choices: "
-        "naf,cern; default: '{}'".format(os.getenv("CF_HTCONDOR_FLAVOR", "naf")),
+        f"naf,cern; default: '{_default_htcondor_flavor}'",
     )
 
     exclude_params_branch = {"max_runtime", "htcondor_cpus", "htcondor_flavor"}
 
     # mapping of environment variables to render variables that are forwarded
-    forward_env_variables = {
-        "CF_LCG_SETUP": "cf_lcg_setup",
+    htcondor_forward_env_variables = {
         "CF_BASE": "cf_base",
+        "CF_REPO_BASE": "cf_repo_base",
+        "CF_LCG_SETUP": "cf_lcg_setup",
         "CF_CERN_USER": "cf_cern_user",
         "CF_STORE_NAME": "cf_store_name",
         "CF_STORE_LOCAL": "cf_store_local",
         "CF_LOCAL_SCHEDULER": "cf_local_scheduler",
-        "CF_STORE_LOCAL": "cf_store_local",
     }
 
     # default upstream dependency task classes
@@ -264,10 +273,10 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
 
     def htcondor_job_config(self, config, job_num, branches):
         # include the voms proxy
-        proxy_file = law.wlcg.get_voms_proxy_file()
-        if not law.wlcg.check_voms_proxy_validity(proxy_file=proxy_file):
+        voms_proxy_file = law.wlcg.get_voms_proxy_file()
+        if not law.wlcg.check_voms_proxy_validity(proxy_file=voms_proxy_file):
             raise Exception("voms proxy not valid, submission aborted")
-        config.input_files["proxy_file"] = proxy_file
+        config.input_files["voms_proxy_file"] = voms_proxy_file
 
         # include the wlcg specific tools script in the input sandbox
         config.input_files["wlcg_tools"] = law.util.law_src_path("contrib/wlcg/scripts/law_wlcg_tools.sh")
@@ -320,11 +329,14 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
             config.render_variables["cf_cmssw_sandbox_names"] = "({})".format(
                 " ".join(map('"{}"'.format, names)))
 
+        # other render variables
         config.render_variables["cf_bootstrap_name"] = "htcondor_standalone"
         config.render_variables["cf_htcondor_flavor"] = self.htcondor_flavor
+        config.render_variables.setdefault("cf_pre_setup_command", "")
+        config.render_variables.setdefault("cf_post_setup_command", "")
 
         # forward env variables
-        for ev, rv in self.forward_env_variables.items():
+        for ev, rv in self.htcondor_forward_env_variables.items():
             config.render_variables[rv] = os.environ[ev]
 
         return config
@@ -332,3 +344,102 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
     def htcondor_use_local_scheduler(self):
         # remote jobs should not communicate with ther central scheduler but with a local one
         return True
+
+
+_default_slurm_partition = os.getenv("CF_SLURM_PARTITION", "cms-uhh")
+_default_slurm_flavor = os.getenv("CF_SLURM_FLAVOR", "naf")
+
+
+class SlurmWorkflow(law.slurm.SlurmWorkflow):
+
+    transfer_logs = luigi.BoolParameter(
+        default=True,
+        significant=False,
+        description="transfer job logs to the output directory; default: True",
+    )
+    max_runtime = law.DurationParameter(
+        default=2.0,
+        unit="h",
+        significant=False,
+        description="maximum runtime; default unit is hours; default: 2",
+    )
+    slurm_partition = luigi.Parameter(
+        default=_default_slurm_partition,
+        significant=False,
+        description=f"target queue partition; default: {_default_slurm_partition}",
+    )
+    slurm_flavor = luigi.ChoiceParameter(
+        default=_default_slurm_flavor,
+        choices=("naf", "cern"),
+        significant=False,
+        description="the 'flavor' (i.e. configuration name) of the batch system; choices: "
+        f"naf; default: '{_default_slurm_flavor}'",
+    )
+
+    exclude_params_branch = {"max_runtime"}
+
+    # mapping of environment variables to render variables that are forwarded
+    slurm_forward_env_variables = {
+        "CF_BASE": "cf_base",
+        "CF_REPO_BASE": "cf_repo_base",
+        "CF_LCG_SETUP": "cf_lcg_setup",
+        "CF_CERN_USER": "cf_cern_user",
+        "CF_STORE_NAME": "cf_store_name",
+        "CF_STORE_LOCAL": "cf_store_local",
+        "CF_LOCAL_SCHEDULER": "cf_local_scheduler",
+    }
+
+    def slurm_output_directory(self):
+        # the directory where submission meta data and logs should be stored
+        return self.local_target(dir=True)
+
+    def slurm_bootstrap_file(self):
+        # each job can define a bootstrap file that is executed prior to the actual job
+        # in order to setup software and environment variables
+        if "CF_REMOTE_BOOTSTRAP_FILE" in os.environ:
+            return os.environ["CF_REMOTE_BOOTSTRAP_FILE"]
+
+        # default
+        return os.path.expandvars("$CF_BASE/columnflow/tasks/framework/remote_bootstrap.sh")
+
+    def slurm_job_config(self, config, job_num, branches):
+        # include the voms proxy
+        voms_proxy_file = law.wlcg.get_voms_proxy_file()
+        if os.path.exists(voms_proxy_file):
+            config.input_files["voms_proxy_file"] = voms_proxy_file
+
+        # include the kerberos ticket when existing
+        if "KRB5CCNAME" in os.environ:
+            kfile = os.environ["KRB5CCNAME"]
+            kerberos_proxy_file = os.sep + kfile.split(os.sep, 1)[-1]
+            if os.path.exists(kerberos_proxy_file):
+                config.input_files["kerberos_proxy_file"] = kerberos_proxy_file
+
+        # set job time and nodes
+        job_time = law.util.human_duration(
+            seconds=law.util.parse_duration(self.max_runtime, input_unit="h") - 1,
+            colon_format=True,
+        )
+        config.custom_content.append(("time", job_time))
+        config.custom_content.append(("nodes", 1))
+
+        # custom, flavor dependent settings
+        if self.slurm_flavor == "naf":
+            # extend kerberos privileges to afs on NAF
+            if "kerberos_proxy_file" in config.input_files:
+                config.render_variables["cf_pre_setup_command"] = "aklog"
+
+        # render variales
+        config.render_variables["cf_bootstrap_name"] = "slurm"
+        config.render_variables.setdefault("cf_pre_setup_command", "")
+        config.render_variables.setdefault("cf_post_setup_command", "")
+
+        # forward env variables
+        for ev, rv in self.slurm_forward_env_variables.items():
+            config.render_variables[rv] = os.environ[ev]
+
+        return config
+
+
+class RemoteWorkflow(HTCondorWorkflow, SlurmWorkflow):
+    pass

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -4,23 +4,20 @@
 # So-called render variables, denoted by "{{name}}", are replaced with variables configured in the
 # remote workflow tasks, e.g. in HTCondorWorkflow.htcondor_job_config() upon job submission.
 
-# Bootstrap function for standalone htcondor jobs, i.e., each jobs fetches a software and repository
-# code bundle and unpacks them to have a standalone environment, independent of the submitting one.
-# The setup script of the repository is sourced with a few environment variables being set before,
-# tailored for remote jobs.
+# Bootstrap function for standalone htcondor jobs.
 bootstrap_htcondor_standalone() {
     # set env variables
     export CF_ON_HTCONDOR="1"
     export CF_REMOTE_JOB="1"
     export CF_CERN_USER="{{cf_cern_user}}"
-    export CF_BASE="${LAW_JOB_HOME}/repo"
+    export CF_REPO_BASE="${LAW_JOB_HOME}/repo"
     export CF_DATA="${LAW_JOB_HOME}/cf_data"
     export CF_SOFTWARE_BASE="${CF_DATA}/software"
     export CF_STORE_NAME="{{cf_store_name}}"
     export CF_STORE_LOCAL="{{cf_store_local}}"
     export CF_LOCAL_SCHEDULER="{{cf_local_scheduler}}"
     export CF_LCG_SETUP="{{cf_lcg_setup}}"
-    export X509_USER_PROXY="${PWD}/{{proxy_file}}"
+    export X509_USER_PROXY="${PWD}/{{voms_proxy_file}}"
 
     # source the lcg software when defined
     if [ ! -z "${CF_LCG_SETUP}" ]; then
@@ -41,8 +38,8 @@ bootstrap_htcondor_standalone() {
 
     # load the repo bundle
     (
-        mkdir -p "${CF_BASE}"
-        cd "${CF_BASE}"
+        mkdir -p "${CF_REPO_BASE}"
+        cd "${CF_REPO_BASE}"
         law_wlcg_get_file "{{cf_repo_uris}}" "{{cf_repo_pattern}}" "repo.tgz" || return "$?"
         tar -xzf "repo.tgz" || return "$?"
         rm "repo.tgz"
@@ -56,10 +53,38 @@ bootstrap_htcondor_standalone() {
         law_wlcg_get_file "${cmssw_sandbox_uris[i]}" "${cmssw_sandbox_patterns[i]}" "${CF_SOFTWARE_BASE}/cmssw_sandboxes/${cmssw_sandbox_names[i]}.tgz" || return "$?"
     done
 
+    # optional custom command before the setup is sourced
+    {{cf_pre_setup_command}}
+
     # source the default repo setup
-    source "${CF_BASE}/setup.sh" "" || return "$?"
+    source "${CF_REPO_BASE}/setup.sh" "" || return "$?"
+
+    # optional custom command after the setup is sourced
+    {{cf_post_setup_command}}
 
     return "0"
 }
 
+
+# Bootstrap function for slurm jobs.
+bootstrap_slurm() {
+    # set env variables
+    export CF_ON_SLURM="1"
+    export CF_REMOTE_JOB="1"
+    export CF_REPO_BASE="{{cf_repo_base}}"
+    export X509_USER_PROXY="{{voms_proxy_file}}"
+    export KRB5CCNAME="FILE:{{kerberos_proxy_file}}"
+
+    # optional custom command before the setup is sourced
+    {{cf_pre_setup_command}}
+
+    # source the default repo setup
+    source "${CF_REPO_BASE}/setup.sh" "" || return "$?"
+
+    # optional custom command after the setup is sourced
+    {{cf_post_setup_command}}
+}
+
+
+# job entry point
 bootstrap_{{cf_bootstrap_name}} "$@"

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -14,7 +14,7 @@ from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, VariablesMixin,
     ShiftSourcesMixin,
 )
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from columnflow.tasks.production import ProduceColumns
 from columnflow.tasks.ml import MLEvaluation
@@ -29,7 +29,7 @@ class CreateHistograms(
     CalibratorsMixin,
     VariablesMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
@@ -190,7 +190,7 @@ class MergeHistograms(
     CalibratorsMixin,
     VariablesMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     only_missing = luigi.BoolParameter(
@@ -291,7 +291,7 @@ class MergeShiftedHistograms(
     VariablesMixin,
     ShiftSourcesMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")

--- a/columnflow/tasks/inference.py
+++ b/columnflow/tasks/inference.py
@@ -12,7 +12,7 @@ from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import dev_sandbox
 
@@ -24,7 +24,7 @@ class CreateDatacards(
     SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -11,7 +11,7 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_f
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorMixin, ProducersMixin, MLModelMixin,
 )
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from columnflow.tasks.production import ProduceColumns
 from columnflow.util import dev_sandbox, safe_div
@@ -24,7 +24,7 @@ class PrepareMLEvents(
     SelectorMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
@@ -168,7 +168,7 @@ class MergeMLEvents(
     SelectorMixin,
     CalibratorsMixin,
     law.tasks.ForestMerge,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     fold = luigi.IntParameter(
@@ -300,7 +300,7 @@ class MLEvaluation(
     SelectorMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = None

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -13,7 +13,7 @@ from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, PlotMixin, CategoriesMixin,
     VariablesMixin, DatasetsProcessesMixin, ShiftSourcesMixin,
 )
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import DotDict
 
@@ -43,7 +43,7 @@ class PlotVariables(
     VariablesMixin,
     ProcessPlotBase,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
@@ -180,7 +180,7 @@ class PlotShiftedVariables(
     ProcessPlotBase,
     ShiftSourcesMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -8,7 +8,7 @@ import law
 
 from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorStepsMixin, ProducerMixin
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
 from columnflow.util import dev_sandbox
 
@@ -19,7 +19,7 @@ class ProduceColumns(
     SelectorStepsMixin,
     CalibratorsMixin,
     law.LocalWorkflow,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -12,7 +12,7 @@ import luigi
 
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorStepsMixin
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.selection import CalibrateEvents, SelectEvents
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
@@ -21,7 +21,13 @@ from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
 ak = maybe_import("awkward")
 
 
-class ReduceEvents(DatasetTask, SelectorStepsMixin, CalibratorsMixin, law.LocalWorkflow, HTCondorWorkflow):
+class ReduceEvents(
+    DatasetTask,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
@@ -338,7 +344,7 @@ class MergeReducedEvents(
     SelectorStepsMixin,
     CalibratorsMixin,
     law.tasks.ForestMerge,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -10,7 +10,7 @@ import law
 
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorMixin
-from columnflow.tasks.framework.remote import HTCondorWorkflow
+from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.calibration import CalibrateEvents
 from columnflow.production import Producer
@@ -20,7 +20,13 @@ from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
 ak = maybe_import("awkward")
 
 
-class SelectEvents(DatasetTask, SelectorMixin, CalibratorsMixin, law.LocalWorkflow, HTCondorWorkflow):
+class SelectEvents(
+    DatasetTask,
+    SelectorMixin,
+    CalibratorsMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
@@ -252,7 +258,7 @@ class MergeSelectionMasks(
     SelectorMixin,
     CalibratorsMixin,
     law.tasks.ForestMerge,
-    HTCondorWorkflow,
+    RemoteWorkflow,
 ):
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,9 @@ setup_columnflow() {
     #   CF_CMSSW_BASE
     #       The directory where CMSSW releases are installed. Might point to $CF_DATA/cmssw. Queried
     #       during the interactive setup.
+    #   CF_REPO_BASE
+    #       The base path of the main repository invoking tasks or scripts. Used by columnflow tasks
+    #       to identify the repository for e.g. bundling. Set to $CF_BASE when not defined already.
     #   CF_VENV_BASE
     #       The directory where virtual envs are installed. Might point to $CF_SOFTWARE_BASE/venvs.
     #       Queried during the interactive setup.
@@ -162,7 +165,7 @@ setup_columnflow() {
         query CF_JOB_BASE "Local directory for storing job files" "\$CF_DATA/jobs"
         query CF_LOCAL_SCHEDULER "Use a local scheduler for law tasks" "True"
         if [ "${CF_LOCAL_SCHEDULER}" != "True" ]; then
-            query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "naf-cms15.desy.de"
+            query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "127.0.0.1"
             query CF_SCHEDULER_PORT "Port of a central scheduler for law tasks" "8082"
         else
             export_and_save CF_SCHEDULER_HOST "127.0.0.1"
@@ -174,6 +177,7 @@ setup_columnflow() {
     cf_setup_interactive "${CF_SETUP_NAME}" "${CF_BASE}/.setups/${CF_SETUP_NAME}.sh" || return "$?"
 
     # continue the fixed setup
+    export CF_REPO_BASE="${CF_REPO_BASE:-$CF_BASE}"
     export CF_VENV_BASE="${CF_SOFTWARE_BASE}/venvs"
     export CF_CI_JOB="$( [ "${GITHUB_ACTIONS}" = "true" ] && echo 1 || echo 0 )"
     export CF_ORIG_PATH="${PATH}"

--- a/setup.sh
+++ b/setup.sh
@@ -419,8 +419,13 @@ cf_init_submodule() {
     # local variables
     local mpath="${1}"
 
-    # do nothing when the path does not exist
-    [ ! -d "${mpath}" ] && return "0"
+    # do nothing in remote jobs
+    [ "$CF_REMOTE_JOB" = "1" ] && return "0"
+
+    # do nothing when the path does not exist or it is not a submodule
+    if [ ! -d "${mpath}" ] || [ ! -f "${mpath}/.git" ] ; then
+        return "0"
+    fi
 
     # initialize the submodule when the directory is empty
     if [ "$( ls -1q "${mpath}" | wc -l )" = "0" ]; then


### PR DESCRIPTION
This PR adds a SlurmWorkflow as well as a common `RemoteWorkflow` that inherits from both `SlurmWorkflow` and `HTCondorWorkflow`. The inheritance of all existing workflows is update so that they can decide whether they use HTCondor or slurm.

In addition, some generalizations were added to make this possible. Overall, the changes mostly affect the job bootstrap script.