### PR TITLE
Allow aux data being passed to SelectionResult.

### DIFF
--- a/columnflow/calibration/jets.py
+++ b/columnflow/calibration/jets.py
@@ -235,7 +235,7 @@ def jec_setup(self: Calibrator, inputs: dict) -> None:
 
     # make selector for JEC text files based on sample type (and era for data)
     if self.dataset_inst.is_data:
-        raise NotImplementedError("JEC for data has not been implemented yet.")
+        raise NotImplementedError("JEC for data has not been implemented yet")
         era = "RunA"  # task.dataset_inst.x.era  # TODO: implement data eras
         resolve_sample = lambda x: x.data[era]
     else:
@@ -298,6 +298,10 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     Apply jet energy resolution smearing and calculate shifts for JER scale factor variations.
     Follows the recommendations given in https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution.
     """
+
+    # complain when running on data
+    if self.dataset_inst.is_data:
+        raise ValueError("attempt to apply jet energy resolution smearing in data")
 
     # save the unsmeared properties in case they are needed later
     events = set_ak_column(events, "Jet.pt_unsmeared", events.Jet.pt)
@@ -423,7 +427,7 @@ def jer_setup(self: Calibrator, inputs: dict) -> None:
 
     # make selector for JEC text files based on sample type
     if self.dataset_inst.is_data:
-        raise ValueError("Attempt to apply jet energy resolution smearing in data!")
+        raise ValueError("attempt to setup jet energy resolution smearing in data")
     resolve_sample = lambda x: x.mc
 
     # pass text files to calibrator method
@@ -462,3 +466,10 @@ def jets(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         events = self[jer](events, **kwargs)
 
     return events
+
+
+@jets.init
+def jets_init(self: Calibrator) -> None:
+    if self.dataset_inst.is_mc:
+        self.uses |= {jer}
+        self.produces |= {jer}

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -88,9 +88,9 @@ class RouteMeta(type):
 
 class Route(object, metaclass=RouteMeta):
     """
-    Route objects describe the location of columns in nested arrays and are basically wrapper around
-    a sequence of nested fields. Additionally, they provide convenience methods for conversions into
-    column names, either in dot or nano-style underscore format.
+    Route objects describe the location of columns in nested arrays and are basically wrappers
+    around a sequence of nested fields. Additionally, they provide convenience methods for
+    conversion into column names, either in dot or nano-style underscore format.
 
     The constructor takes another *route* instance, a sequence of strings, or a string in dot format
     to initialize the fields. Most operators are overwritten to work with routes in a tuple-like
@@ -584,7 +584,7 @@ def set_ak_column(
     # force creating a view for consistent behavior
     ak_array = ak_array[ak_array.fields]
 
-    # try to remove the route first so that existing columns are not overwritten but replaced
+    # try to remove the route first so that existing columns are not overwritten but re-inserted
     ak_array = remove_ak_column(ak_array, route, silent=True)
 
     # trivial case
@@ -1687,7 +1687,7 @@ class ChunkedReader(object):
         ) as reader:
             for (chunk, masks), position in reader:
                 # chunk is a NanoAODEventsArray as returned by read_coffea_root
-                # masks is a awkward array as returned by read_awkward_parquet
+                # masks is an awkward array as returned by read_awkward_parquet
                 selected_jet_pts = chunk[masks].Jet.pt
                 print(f"selected jet pts of chunk {chunk.index}: {selected_jet_pts}")
 

--- a/columnflow/example_config/analysis_st.py
+++ b/columnflow/example_config/analysis_st.py
@@ -115,10 +115,10 @@ def add_aliases(shift_source, aliases):
 
 # register shifts
 config_2018.add_shift(name="nominal", id=0)
-config_2018.add_shift(name="tune_up", id=1, type="shape", aux={"disjoint_from_nominal": True})
-config_2018.add_shift(name="tune_down", id=2, type="shape", aux={"disjoint_from_nominal": True})
-config_2018.add_shift(name="hdamp_up", id=3, type="shape", aux={"disjoint_from_nominal": True})
-config_2018.add_shift(name="hdamp_down", id=4, type="shape", aux={"disjoint_from_nominal": True})
+config_2018.add_shift(name="tune_up", id=1, type="shape", tags={"disjoint_from_nominal"})
+config_2018.add_shift(name="tune_down", id=2, type="shape", tags={"disjoint_from_nominal"})
+config_2018.add_shift(name="hdamp_up", id=3, type="shape", tags={"disjoint_from_nominal"})
+config_2018.add_shift(name="hdamp_down", id=4, type="shape", tags={"disjoint_from_nominal"})
 config_2018.add_shift(name="minbias_xs_up", id=7, type="shape")
 config_2018.add_shift(name="minbias_xs_down", id=8, type="shape")
 add_aliases("minbias_xs", {"pu_weight": "pu_weight_{name}"})

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -88,6 +88,9 @@ class SelectionResult(object):
             objects={"jet": array, "muon": array, ...}
         )
         res.to_ak()
+
+    Arbitrary, auxiliary information (additional arrays, or other objects) that should not be stored
+    in dumped akward arrays can be placed in the *aux* dictionary.
     """
 
     def __init__(
@@ -95,6 +98,7 @@ class SelectionResult(object):
         main: Optional[Union[DotDict, dict]] = None,
         steps: Optional[Union[DotDict, dict]] = None,
         objects: Optional[Union[DotDict, dict]] = None,
+        aux: Optional[Union[DotDict, dict]] = None,
     ):
         super().__init__()
 
@@ -102,6 +106,7 @@ class SelectionResult(object):
         self.main = DotDict.wrap(main or {})
         self.steps = DotDict.wrap(steps or {})
         self.objects = DotDict.wrap(objects or {})
+        self.aux = DotDict.wrap(aux or {})
 
     def __iadd__(self, other: Union["SelectionResult", None]) -> "SelectionResult":
         """
@@ -121,6 +126,8 @@ class SelectionResult(object):
         self.steps.update(other.steps)
         # use deep merging for objects
         law.util.merge_dicts(self.objects, other.objects, inplace=True, deep=True)
+        # shallow update for aux
+        self.aux.update(other.aux)
 
         return self
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -863,6 +863,7 @@ def wrapper_factory(
                 description="names or name patterns of configs to use; can also be the key of a "
                 "mapping defined in the 'config_groups' auxiliary data of the analysis; default: "
                 "('*',)",
+                brace_expand=True,
             )
         if has_skip_configs:
             skip_configs = law.CSVParameter(
@@ -870,6 +871,7 @@ def wrapper_factory(
                 description="names or name patterns of configs to skip after evaluating --configs; "
                 "can also be the key of a mapping defined in the 'config_groups' auxiliary data "
                 "of the analysis; empty default",
+                brace_expand=True,
             )
         if has_datasets:
             datasets = law.CSVParameter(
@@ -877,6 +879,7 @@ def wrapper_factory(
                 description="names or name patterns of datasets to use; can also be the key of a "
                 "mapping defined in the 'dataset_groups' auxiliary data of the corresponding "
                 "config; default: ('*',)",
+                brace_expand=True,
             )
         if has_skip_datasets:
             skip_datasets = law.CSVParameter(
@@ -884,6 +887,7 @@ def wrapper_factory(
                 description="names or name patterns of datasets to skip after evaluating "
                 "--datasets; can also be the key of a mapping defined in the 'dataset_groups' "
                 "auxiliary data of the corresponding config; empty default",
+                brace_expand=True,
             )
         if has_shifts:
             shifts = law.CSVParameter(
@@ -891,6 +895,7 @@ def wrapper_factory(
                 description="names or name patterns of shifts to use; can also be the key of a "
                 "mapping defined in the 'shift_groups' auxiliary data of the corresponding "
                 "config; default: ('nominal',)",
+                brace_expand=True,
             )
         if has_skip_shifts:
             skip_shifts = law.CSVParameter(
@@ -898,6 +903,7 @@ def wrapper_factory(
                 description="names or name patterns of shifts to skip after evaluating --shifts; "
                 "can also be the key of a mapping defined in the 'shift_groups' auxiliary data "
                 "of the corresponding config; empty default",
+                brace_expand=True,
             )
 
         def __init__(self, *args, **kwargs):
@@ -1002,7 +1008,7 @@ def wrapper_factory(
                     )
                     if not datasets:
                         raise ValueError(
-                            f"no datasets found in config {self.config_inst} matching "
+                            f"no datasets found in config {config_inst} matching "
                             f"{self.datasets}",
                         )
                     if self.wrapper_has_skip_datasets:
@@ -1015,7 +1021,7 @@ def wrapper_factory(
                         datasets = [d for d in datasets if d not in skip_datasets]
                         if not datasets:
                             raise ValueError(
-                                f"no datasets found in config {self.config_inst} after skipping "
+                                f"no datasets found in config {config_inst} after skipping "
                                 f"{self.skip_datasets}",
                             )
                     prod_sequences.append(sorted(datasets))

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -512,7 +512,7 @@ class CategoriesMixin(ConfigTask):
         default=("1mu",),
         description="comma-separated category names or patterns to select; can also be the key of "
         "a mapping defined in 'category_groups' auxiliary data of the config; default: ('1mu',)",
-        brace_expand=True
+        brace_expand=True,
     )
 
     allow_empty_categories = False
@@ -558,7 +558,7 @@ class VariablesMixin(ConfigTask):
         description="comma-separated variable names or patterns to select; can also be the key of "
         "a mapping defined in the 'variable_group' auxiliary data of the config; when empty, uses "
         "all variables of the config; empty default",
-        brace_expand=True
+        brace_expand=True,
     )
 
     default_variables = None

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -85,6 +85,7 @@ class CalibratorsMixin(ConfigTask):
         default=(),
         description="comma-separated names of calibrators to be applied; default: value of the "
         "'default_calibrator' config in a 1-tuple",
+        brace_expand=True,
     )
 
     @classmethod
@@ -214,6 +215,7 @@ class SelectorStepsMixin(SelectorMixin):
         default=(),
         description="a subset of steps of the selector to apply; uses all steps when empty; "
         "empty default",
+        brace_expand=True,
     )
 
     selector_steps_order_sensitive = False
@@ -313,6 +315,7 @@ class ProducersMixin(ConfigTask):
     producers = law.CSVParameter(
         default=(),
         description="comma-separated names of producers to be applied; empty default",
+        brace_expand=True,
     )
 
     @classmethod
@@ -415,7 +418,7 @@ class MLModelMixin(ConfigTask):
         # shall be used in the training
         return (
             dataset_inst in self.ml_model_inst.used_datasets and
-            not shift_inst.x("disjoint_from_nominal", False)
+            not shift_inst.has_tag("disjoint_from_nominal")
         )
 
     def store_parts(self) -> law.util.InsertableDict:
@@ -430,6 +433,7 @@ class MLModelsMixin(ConfigTask):
     ml_models = law.CSVParameter(
         default=(),
         description="comma-separated names of ML models to be applied; empty default",
+        brace_expand=True,
     )
 
     @classmethod
@@ -508,6 +512,7 @@ class CategoriesMixin(ConfigTask):
         default=("1mu",),
         description="comma-separated category names or patterns to select; can also be the key of "
         "a mapping defined in 'category_groups' auxiliary data of the config; default: ('1mu',)",
+        brace_expand=True
     )
 
     allow_empty_categories = False
@@ -553,6 +558,7 @@ class VariablesMixin(ConfigTask):
         description="comma-separated variable names or patterns to select; can also be the key of "
         "a mapping defined in the 'variable_group' auxiliary data of the config; when empty, uses "
         "all variables of the config; empty default",
+        brace_expand=True
     )
 
     default_variables = None
@@ -608,12 +614,14 @@ class DatasetsProcessesMixin(ConfigTask):
         "mapping defined in the 'dataset_groups' auxiliary data of the config; when empty, uses "
         "all datasets registered in the config that contain any of the selected --processes; empty "
         "default",
+        brace_expand=True,
     )
     processes = law.CSVParameter(
         default=(),
         description="comma-separated process names or patterns for filtering processes; can also "
         "be the key of a mapping defined in the 'process_groups' auxiliary data of the config; "
         "uses all processes of the config when empty; empty default",
+        brace_expand=True,
     )
 
     allow_empty_datasets = False

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -161,7 +161,7 @@ class ReduceEvents(
                     for dst_name in dst_names:
                         object_mask = sel.objects[src_name, dst_name][event_mask]
                         dst_collection = events[src_name][object_mask]
-                        set_ak_column(events, dst_name, dst_collection)
+                        events = set_ak_column(events, dst_name, dst_collection)
 
                 # remove columns
                 events = route_filter(events)

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,6 +1,7 @@
-# version 2
+# version 3
 
 pyarrow==6.0.*
 coffea==0.7.*
 awkward==1.8.*
 uproot==4.2.3
+tabulate==0.8.*


### PR DESCRIPTION
This PR contains 3 different types of changes:

1. SelectionResult now allows for keeping auxiliary data that can be passed around between selectors and that is not serialized in `to_ak`.
2. All CSV-based parameter support shell-style brace expansion.
3. Various minor tweaks (mostly wordings in exceptions texts).