### PR TITLE
Restructuring of Plotting base tasks and adding process_settings parameter to plotting

### DIFF
--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -239,7 +239,6 @@ def plot_variable_per_process(
     for process_inst, h in hists.items():
         # get settings for this process
         settings = process_settings.get(process_inst.name, {})
-        print(settings)
         color = settings.get("color", process_inst.color)
         label = settings.get("label", process_inst.label)
 

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -224,30 +224,40 @@ def plot_variable_per_process(
     style_config: Optional[dict] = None,
     shape_norm: Optional[bool] = False,
     yscale: Optional[str] = "",
-    scale_process: Optional[dict] = None,
+    process_settings: Optional[dict] = None,
     **kwargs,
 ) -> plt.Figure:
 
+    # process_settings
+    if not process_settings:
+        process_settings = {}
+
     # separate histograms into stack, lines and data hists
-    process_lines = kwargs.get("process_lines", ())
     data_hists, mc_hists, mc_colors, mc_labels = [], [], [], []
     line_hists, line_colors, line_labels = [], [], []
 
     for process_inst, h in hists.items():
-        if scale_process and process_inst.name in scale_process.keys():
-            h = h * float(scale_process[process_inst.name])
-            process_inst.label = process_inst.label + " x" + scale_process[process_inst.name]
+        # get settings for this process
+        settings = process_settings.get(process_inst.name, {})
+        print(settings)
+        color = settings.get("color", process_inst.color)
+        label = settings.get("label", process_inst.label)
+
+        if "scale" in settings.keys():
+            h = h * settings["scale"]
+            label = f"{label} x{settings['scale']}"
+
         if process_inst.is_data:
             data_hists.append(h)
         elif process_inst.is_mc:
-            if process_inst.name in process_lines:
+            if "unstack" in settings:
                 line_hists.append(h)
-                line_colors.append(process_inst.color)
-                line_labels.append(process_inst.label)
+                line_colors.append(color)
+                line_labels.append(label)
             else:
                 mc_hists.append(h)
-                mc_colors.append(process_inst.color)
-                mc_labels.append(process_inst.label)
+                mc_colors.append(color)
+                mc_labels.append(label)
 
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -144,8 +144,7 @@ def plot_all(
     else:
         fig, ax = plt.subplots()
 
-    for key in plot_config:
-        cfg = plot_config[key]
+    for key, cfg in plot_config.items():
         if "method" not in cfg:
             raise ValueError("No method given in plot_cfg entry {key}")
         method = cfg["method"]
@@ -458,11 +457,22 @@ def plot_cutflow(
         },
     }
 
+    # update xticklabels based on config
+    xticklabels = []
+    selector_step_labels = config_inst.x("selector_step_labels", {})
+    for xtl in list(mc_hists[0].axes["step"]):
+        xticklabels.append(selector_step_labels.get(xtl, xtl))
+
     default_style_config = {
         "ax_cfg": {
             "ylabel": "Selection efficiency",
             "xlabel": "Selection steps",
+            "xticklabels": xticklabels,
             "yscale": yscale,
+        },
+        "rax_cfg": {
+            "xlabel": "Selection steps",
+            "xticklabels": xticklabels,
         },
         "legend_cfg": {
             "loc": "upper right",

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -223,7 +223,7 @@ def plot_variable_per_process(
     variable_inst: od.variable,
     style_config: Optional[dict] = None,
     shape_norm: Optional[bool] = False,
-    y_scale: Optional[str] = "",
+    yscale: Optional[str] = "",
     scale_process: Optional[dict] = None,
     **kwargs,
 ) -> plt.Figure:
@@ -232,12 +232,10 @@ def plot_variable_per_process(
     process_lines = kwargs.get("process_lines", ())
     data_hists, mc_hists, mc_colors, mc_labels = [], [], [], []
     line_hists, line_colors, line_labels = [], [], []
-    print(scale_process)
+
     for process_inst, h in hists.items():
         if scale_process and process_inst.name in scale_process.keys():
-            print("test", h.values())
             h = h * float(scale_process[process_inst.name])
-            print(h.values())
             process_inst.label = process_inst.label + " x" + scale_process[process_inst.name]
         if process_inst.is_data:
             data_hists.append(h)
@@ -298,15 +296,15 @@ def plot_variable_per_process(
         }
 
     # setup style config
-    if not y_scale:
-        y_scale = "log" if variable_inst.log_y else "linear"
+    if not yscale:
+        yscale = "log" if variable_inst.log_y else "linear"
 
     default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
             "xlabel": variable_inst.get_full_x_title(),
-            "yscale": y_scale,
+            "yscale": yscale,
         },
         "rax_cfg": {
             "ylabel": "Data / MC",
@@ -330,7 +328,7 @@ def plot_variable_variants(
     variable_inst: od.variable,
     style_config: Optional[dict] = None,
     shape_norm: bool = False,
-    y_scale: str = "",
+    yscale: str = "",
     **kwargs,
 ) -> plt.Figure:
     plot_config = OrderedDict()
@@ -346,15 +344,15 @@ def plot_variable_variants(
         }
 
     # setup style config
-    if not y_scale:
-        y_scale = "log" if variable_inst.log_y else "linear"
+    if not yscale:
+        yscale = "log" if variable_inst.log_y else "linear"
 
     default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
             "xlabel": variable_inst.get_full_x_title(),
-            "yscale": y_scale,
+            "yscale": yscale,
         },
         "rax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
@@ -381,7 +379,7 @@ def plot_shifted_variable(
     variable_inst: od.variable,
     style_config: Optional[dict] = None,
     shape_norm: bool = False,
-    y_scale: str = "",
+    yscale: str = "",
     **kwargs,
 ) -> plt.Figure:
 
@@ -411,14 +409,14 @@ def plot_shifted_variable(
     }
 
     # setup style config
-    if not y_scale:
-        y_scale = "log" if variable_inst.log_y else "linear"
+    if not yscale:
+        yscale = "log" if variable_inst.log_y else "linear"
 
     default_style_config = {
         "ax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
             "ylabel": variable_inst.get_full_y_title(),
-            "yscale": y_scale,
+            "yscale": yscale,
         },
         "rax_cfg": {
             "xlim": (variable_inst.x_min, variable_inst.x_max),
@@ -457,7 +455,7 @@ def plot_cutflow(
         h_mc_stack = hist.Stack(*mc_hists)
 
     # get configs from kwargs
-    y_scale = kwargs.get("y_scale") or "linear"
+    yscale = kwargs.get("yscale") or "linear"
 
     # setup plotting configs
     plot_config = {

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -303,7 +303,6 @@ class PlotCutflow(
                 hists=hists,
                 config_inst=self.config_inst,
                 **self.get_plot_parameters(),
-
             )
 
             # save the plot

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -235,7 +235,8 @@ class PlotCutflow(
         }
 
     def output(self):
-        return self.target(f"cutflow__cat_{self.branch_data}.pdf")
+        suffix = f"__{self.plot_suffix}" if self.plot_suffix else ""
+        return self.target(f"cutflow__cat_{self.branch_data}{suffix}.pdf")
 
     @law.decorator.log
     @PlotMixin.view_output_plots
@@ -406,14 +407,15 @@ class PlotCutflowVariables(
 
     def output(self):
         b = self.branch_data
+        suffix = f"__{self.plot_suffix}" if self.plot_suffix else ""
         if self.per_plot == "processes":
             return law.SiblingFileCollection({
-                s: self.local_target(f"plot__cat_{b.category}__var_{b.variable}__step{i}_{s}.pdf")
+                s: self.local_target(f"plot__cat_{b.category}__var_{b.variable}__step{i}_{s}{suffix}.pdf")
                 for i, s in enumerate(self.chosen_steps)
             })
         else:  # per_plot == "steps"
             return law.SiblingFileCollection({
-                p: self.local_target(f"plot__cat_{b.category}__var_{b.variable}__proc_{p}.pdf")
+                p: self.local_target(f"plot__cat_{b.category}__var_{b.variable}__proc_{p}{suffix}.pdf")
                 for p in self.processes
             })
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -14,8 +14,8 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, VariablesMixin, PlotMixin, ChunkedReaderMixin,
 )
+from columnflow.tasks.framework.plotting import ProcessPlotBase
 from columnflow.tasks.framework.remote import RemoteWorkflow
-from columnflow.tasks.plotting import ProcessPlotBase
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -186,6 +186,15 @@ class PlotCutflow(
     # default upstream dependency task classes
     dep_CreateCutflowHistograms = CreateCutflowHistograms
 
+    def get_plot_parameters(self):
+        params = super().get_plot_parameters()
+
+        # no ratio plot implemented: disable ratio plot for `plot_cutflow`
+        if self.plot_function_name == "columnflow.plotting.example.plot_cutflow":
+            params["skip_ratio"] = True
+
+        return params
+
     def create_branch_map(self):
         # one category per branch
         if not self.categories:

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -781,52 +781,6 @@ class PlotMixin(AnalysisTask):
         description="a command to execute after the task has run to visualize plots right in the "
         "terminal; no default",
     )
-    skip_ratio = luigi.BoolParameter(
-        default=False,
-        significant=False,
-        description="when True, no ratio (usually Data/Bkg ratio) is drawn in the lower panel; "
-        "default: False",
-    )
-    shape_norm = luigi.BoolParameter(
-        default=False,
-        significant=False,
-        description="when True, each process is normalized on it's integral in the upper panel; "
-        "default: False",
-    )
-    skip_legend = luigi.BoolParameter(
-        default=False,
-        significant=False,
-        description="when True, no legend is drawn; default: False",
-    )
-    skip_cms = luigi.BoolParameter(
-        default=False,
-        significant=False,
-        description="when True, no CMS logo is drawn; default: False",
-    )
-    y_scale = luigi.ChoiceParameter(
-        choices=(law.NO_STR, "linear", "log"),
-        default=law.NO_STR,
-        significant=False,
-        description="string parameter to define the y-axis scale of the plot in the upper panel; "
-        "choices: NO_STR,linear,log; no default",
-    )
-    process_lines = law.CSVParameter(
-        default=(),
-        description="comma-separated process names or patterns to plot as individual lines; "
-        "can also be the key of a mapping defined in the 'process_groups' auxiliary data of "
-        "the config; uses no process when empty; empty default",
-    )
-
-    def get_plot_parameters(self):
-        # convert parameters to usable values during plotting
-        return {
-            "skip_ratio": self.skip_ratio,
-            "shape_norm": self.shape_norm,
-            "skip_legend": self.skip_legend,
-            "skip_cms": self.skip_cms,
-            "yscale": None if self.y_scale == law.NO_STR else self.y_scale,
-            "process_lines": self.process_lines,
-        }
 
     def get_plot_func(self, func_name: str) -> Callable:
         """

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+
+"""
+Base tasks for different types of plotting tasks
+"""
+
+import law
+import luigi
+
+from columnflow.tasks.framework.mixins import PlotMixin, CategoriesMixin, DatasetsProcessesMixin
+
+
+class PlotBase(PlotMixin):
+    """
+    Base class for all plotting tasks.
+    """
+
+    skip_legend = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, no legend is drawn; default: False",
+    )
+    skip_cms = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, no CMS logo is drawn; default: False",
+    )
+
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        return {
+            "skip_legend": self.skip_legend,
+            "skip_cms": self.skip_cms,
+        }
+
+
+class PlotBase1D(PlotBase):
+    """
+    Base class for plotting tasks creating 1-dimensional plots.
+    """
+
+    skip_ratio = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, no ratio (usually Data/Bkg ratio) is drawn in the lower panel; "
+        "default: False",
+    )
+    y_scale = luigi.ChoiceParameter(
+        choices=(law.NO_STR, "linear", "log"),
+        default=law.NO_STR,
+        significant=False,
+        description="string parameter to define the y-axis scale of the plot in the upper panel; "
+        "choices: NO_STR,linear,log; no default",
+    )
+    shape_norm = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, each process is normalized on it's integral in the upper panel; "
+        "default: False",
+    )
+
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        params = super().get_plot_parameters()
+
+        params["skip_ratio"] = self.skip_ratio
+        params["y_scale"] = None if self.y_scale == law.NO_STR else self.y_scale
+        params["shape_norm"] = self.shape_norm
+
+        return params
+
+
+class ProcessPlotBase(
+    CategoriesMixin,
+    DatasetsProcessesMixin,
+    PlotBase1D,
+):
+    """
+    Base class for tasks creating plots where contributions of different processes are shown.
+    """
+
+    process_lines = law.CSVParameter(
+        default=(),
+        significant=False,
+        description="comma-separated process names or patterns to plot as individual lines; "
+        "can also be the key of a mapping defined in the 'process_groups' auxiliary data of "
+        "the config; uses no process when empty; empty default",
+    )
+
+    scale_process = law.CSVParameter(
+        default=(),
+        significant=False,
+        description="comma-seperated process names and values with which to scale the process, "
+        "e.g. ('signal:100'); empty default",
+    )
+
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        params = super().get_plot_parameters()
+
+        params["process_lines"] = self.process_lines
+        params["scale_process"] = [s.split(":") for s in self.scale_process]
+
+        return params
+
+    def store_parts(self):
+        parts = super().store_parts()
+        part = f"datasets_{self.datasets_repr}__processes_{self.processes_repr}"
+        parts.insert_before("version", "plot", part)
+        return parts
+
+
+class PlotBase2D(PlotBase):
+    """
+    Base class for plotting tasks creating 2-dimensional plots.
+    """
+
+    z_scale = luigi.ChoiceParameter(
+        choices=(law.NO_STR, "linear", "log"),
+        default=law.NO_STR,
+        significant=False,
+        description="string parameter to define the z-axis scale of the plot in the upper panel; "
+        "choices: NO_STR,linear,log; no default",
+    )
+
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        params = super().get_plot_parameters()
+
+        params["z_scale"] = None if self.z_scale == law.NO_STR else self.z_scale
+
+        return params

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -99,7 +99,7 @@ class ProcessPlotBase(
         params = super().get_plot_parameters()
 
         params["process_lines"] = self.process_lines
-        params["scale_process"] = [s.split(":") for s in self.scale_process]
+        params["scale_process"] = {i[0]: i[1] for i in [s.split(":") for s in self.scale_process]}
 
         return params
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -45,7 +45,7 @@ class PlotBase1D(PlotBase):
         description="when True, no ratio (usually Data/Bkg ratio) is drawn in the lower panel; "
         "default: False",
     )
-    y_scale = luigi.ChoiceParameter(
+    yscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
         default=law.NO_STR,
         significant=False,
@@ -64,7 +64,7 @@ class PlotBase1D(PlotBase):
         params = super().get_plot_parameters()
 
         params["skip_ratio"] = self.skip_ratio
-        params["y_scale"] = None if self.y_scale == law.NO_STR else self.y_scale
+        params["yscale"] = None if self.yscale == law.NO_STR else self.yscale
         params["shape_norm"] = self.shape_norm
 
         return params

--- a/columnflow/tasks/framework/plotting.py~
+++ b/columnflow/tasks/framework/plotting.py~
@@ -1,0 +1,6 @@
+# coding: utf-8
+
+"""
+Base tasks for different types of plotting tasks
+"""
+

--- a/columnflow/tasks/framework/plotting.py~
+++ b/columnflow/tasks/framework/plotting.py~
@@ -1,6 +1,0 @@
-# coding: utf-8
-
-"""
-Base tasks for different types of plotting tasks
-"""
-

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -71,7 +71,8 @@ class PlotVariables(
 
     def output(self):
         b = self.branch_data
-        return self.target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
+        suffix = f"_{self.plot_suffix}" if self.plot_suffix else ""
+        return self.target(f"plot__cat_{b.category}__var_{b.variable}{suffix}.pdf")
 
     @law.decorator.log
     @PlotMixin.view_output_plots

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -10,28 +10,13 @@ import law
 
 from columnflow.tasks.framework.base import ShiftTask
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, PlotMixin, CategoriesMixin,
-    VariablesMixin, DatasetsProcessesMixin, ShiftSourcesMixin,
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, PlotMixin,
+    VariablesMixin, ShiftSourcesMixin,
 )
+from columnflow.tasks.framework.plotting import ProcessPlotBase
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import DotDict
-
-
-class ProcessPlotBase(
-    CategoriesMixin,
-    DatasetsProcessesMixin,
-    PlotMixin,
-):
-    """
-    Base class for tasks creating plots where contributions of different processes are shown.
-    """
-
-    def store_parts(self):
-        parts = super().store_parts()
-        part = f"datasets_{self.datasets_repr}__processes_{self.processes_repr}"
-        parts.insert_before("version", "plot", part)
-        return parts
 
 
 class PlotVariables(

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -71,7 +71,7 @@ class PlotVariables(
 
     def output(self):
         b = self.branch_data
-        suffix = f"_{self.plot_suffix}" if self.plot_suffix else ""
+        suffix = f"__{self.plot_suffix}" if self.plot_suffix else ""
         return self.target(f"plot__cat_{b.category}__var_{b.variable}{suffix}.pdf")
 
     @law.decorator.log
@@ -212,7 +212,8 @@ class PlotShiftedVariables(
 
     def output(self):
         b = self.branch_data
-        return self.target(f"plot__cat_{b.category}__var_{b.variable}.pdf")
+        suffix = f"__{self.plot_suffix}" if self.plot_suffix else ""
+        return self.target(f"plot__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}{suffix}.pdf")
 
     @law.decorator.log
     @PlotMixin.view_output_plots


### PR DESCRIPTION
This PR moves most plotting parameters from the `PlotMixin` into different base plotting tasks. The structure is (atm) setup as follows:
`PlotMixin` -> `PlotBase` ->`PlotBase1D` ->`ProcessPlotBase` and
`PlotMxin` -> `PlotBase` -> `PlotBase2D` (dummy since not yet used in any tasks)

This PR also allows setting the style of individual processes in plots on the command line (or as default in the config)
Possible parameters that are supported at the moment are: `label`, `color` (matplotlib default colors or hex code), `unstack` and `scale`, but can be implemented in the plotting function independently of the task.
An exemplary command would look like
```
law run cf.PlotVariables --version v1 --process-settings tt,label="tt custom label",color=red:st,unstack,scale=10
```
Or alternatively
`law run cf.PlotVariables --version v1 --process-settings default` with
```
process_settings_groups = {
    "default" : [["tt", "label=tt custom label", "color=red"], ["st", "unstack", "scale=10"]],
}
```

Other changes:
- you can now change the xticklabels of the Cutflow plots via setting up a `selector_step_labels` dictionary in the config (mapping the name of a selector step to a label).
- The `plot_suffix` parameter was added to allow customizing of plot output names. (For completeness I could also add a `plot_prefix` parameter)
- some minor changes in plotting functions