### PR TITLE
Base software stack upon conda with python 3.9

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python 🐍
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install dependencies ☕️
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup python 🐍
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install dependencies ☕️
         run: |
@@ -91,7 +91,7 @@ jobs:
       - name: Setup python 🐍
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install dependencies ☕️
         run: |

--- a/columnflow/example_config/analysis_st.py
+++ b/columnflow/example_config/analysis_st.py
@@ -29,15 +29,16 @@ analysis_st = Analysis(
 analysis_st.set_aux("versions", {
 })
 
-# sandboxes that might be required by remote tasks
-# (used in PrepareJobSandboxes)
+# files of bash sandboxes that might be required by remote tasks
+# (used in cf.HTCondorWorkflow)
 analysis_st.set_aux("job_sandboxes", [
-    "bash::$CF_BASE/sandboxes/venv_columnar.sh",
+    "$CF_BASE/sandboxes/venv_columnar.sh",
 ])
 
-# cmssw sandboxes that should be bundled for remote jobs in case they are needed
+# files of cmssw sandboxes that should be bundled for remote jobs in case they are needed
+# (used in cf.HTCondorWorkflow)
 analysis_st.set_aux("cmssw_sandboxes", [
-    # "cmssw_default.sh",
+    # "$CF_BASE/sandboxes/cmssw_default.sh",
 ])
 
 # config groups for conveniently looping over certain configs

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -24,6 +24,7 @@ class CalibrateEvents(
     RemoteWorkflow,
 ):
 
+    # default sandbox, might be overwritten by calibrator function
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(GetDatasetLFNs.shifts)

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -127,10 +127,11 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                 input_stat = input_file.exists(stat=True)
                 duration = time.perf_counter() - t1
                 i += 1
+                logger.info(f"file does {'' if input_stat else 'not'} exist at fs {fs}")
 
                 # when the stat query took longer than 2 seconds, eagerly try the next fs
                 # and check if it responds faster and if so, take it instead
-                if eager_lookup:
+                if input_stat and eager_lookup:
                     if (
                         isinstance(eager_lookup, int) and
                         not isinstance(eager_lookup, bool) and
@@ -138,7 +139,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                     ):
                         logger.debug(f"eager fs lookup skipped for fs {fs} at index {i}")
                     else:
-                        if input_stat and duration > 2 and not last_working and i < len(remote_fs):
+                        if input_stat and not last_working and duration > 2.0 and i < len(remote_fs):
                             last_working = fs, input_file, input_stat, duration
                             logger.debug("duration exceeded 2s, checking next fs for comparison")
                             continue

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -25,6 +25,7 @@ class ProduceColumns(
     RemoteWorkflow,
 ):
 
+    # default sandbox, might be overwritten by producer function
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(MergeReducedEvents.shifts)

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -29,6 +29,7 @@ class SelectEvents(
     RemoteWorkflow,
 ):
 
+    # default sandbox, might be overwritten by selector function
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = GetDatasetLFNs.shifts | CalibrateEvents.shifts

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -292,8 +292,8 @@ def ensure_proxy(
     the decorated method.
     """
     def before_call():
-        # do nothing for grid jobs
-        if env_is_grid:
+        # do nothing in remote jobs
+        if env_is_remote:
             return None
 
         # check the proxy validity

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -169,18 +169,18 @@ setup_venv() {
 
         # update pip
         echo -e "\n\x1b[0;49;35mupdating pip\x1b[0m"
-        python3 -m pip install -U pip || ( rm -f "${pending_flag_file}" && return "13" )
+        python -m pip install -U pip || ( rm -f "${pending_flag_file}" && return "13" )
 
         # install basic production requirements
         if ! ${requirement_files_contains_prod}; then
             echo -e "\n\x1b[0;49;35minstalling requirement file ${CF_BASE}/requirements_prod.txt\x1b[0m"
-            python3 -m pip install -r "${CF_BASE}/requirements_prod.txt" || ( rm -f "${pending_flag_file}" && return "14" )
+            python -m pip install -r "${CF_BASE}/requirements_prod.txt" || ( rm -f "${pending_flag_file}" && return "14" )
         fi
 
         # install requirement files
         for f in ${requirement_files[@]}; do
             echo -e "\n\x1b[0;49;35minstalling requirement file ${f}\x1b[0m"
-            python3 -m pip install -r "${f}" || ( rm -f "${pending_flag_file}" && return "15" )
+            python -m pip install -r "${f}" || ( rm -f "${pending_flag_file}" && return "15" )
             echo
         done
 

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -37,10 +37,13 @@
 # fetched from a local or remote location and unpacked.
 
 setup_venv() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
     local orig_dir="${PWD}"
+
+    # source the main setup script to access helpers
+    CF_SKIP_SETUP="1" source "${this_dir}/../setup.sh" "" || return "$?"
 
 
     #
@@ -115,106 +118,136 @@ setup_venv() {
     # ensure the CF_VENV_BASE exists
     mkdir -p "${CF_VENV_BASE}"
 
-    # remove the current installation
-    if [ "${mode}" = "reinstall" ]; then
-        echo "removing current installation at $install_path (mode '${mode}')"
-        rm -rf "${install_path}"
-    fi
-
-    # complain in remote jobs when the env is not installed
-    if [ "${CF_REMOTE_JOB}" = "1" ] && [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
-        >&2 echo "the venv ${CF_VENV_NAME} is not installed but should be provided externally for remote jobs"
-        return "9"
-    fi
-
-    # from here onwards, files and directories could be created and in order to prevent race
-    # conditions from multiple processes, guard the setup with the pending_flag_file and sleep for a
-    # random amount of seconds between 0 and 10 to further reduce the chance of simultaneously
-    # starting processes getting here at the same time
-    if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
-        local sleep_counter="0"
-        sleep "$( python3 -c 'import random;print(random.random() * 10)')"
-        # when the file is older than 30 minutes, consider it a dangling leftover from a
-        # previously failed installation attempt and delete it.
-        if [ -f "${pending_flag_file}" ]; then
-            local flag_file_age="$(( $( date +%s ) - $( date +%s -r "${pending_flag_file}" )))"
-            [ "${flag_file_age}" -ge "1800" ] && rm -f "${pending_flag_file}"
-        fi
-        # start the sleep loop
-        while [ -f "${pending_flag_file}" ]; do
-            # wait at most 15 minutes
-            sleep_counter="$(( $sleep_counter + 1 ))"
-            if [ "${sleep_counter}" -ge 180 ]; then
-                >&2 echo "venv ${CF_VENV_NAME} is setup in different process, but number of sleeps exceeded"
-                return "10"
-            fi
-            echo -e "\x1b[0;49;36mvenv ${CF_VENV_NAME} already being setup in different process, sleep ${sleep_counter} / 180\x1b[0m"
-            sleep 5
-        done
-    fi
-
     # possible return value
     local ret="0"
 
-    # install or fetch when not existing
-    if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
-        touch "${pending_flag_file}"
-        echo "installing venv at ${install_path}"
-
-        rm -rf "${install_path}"
-        cf_create_venv "${CF_VENV_NAME}" || ( rm -f "${pending_flag_file}" && return "11" )
-
-        # activate it
-        source "${install_path}/bin/activate" "" || ( rm -f "${pending_flag_file}" && return "12" )
-
-        # update pip
-        echo -e "\n\x1b[0;49;35mupdating pip\x1b[0m"
-        python -m pip install -U pip || ( rm -f "${pending_flag_file}" && return "13" )
-
-        # install basic production requirements
-        if ! ${requirement_files_contains_prod}; then
-            echo -e "\n\x1b[0;49;35minstalling requirement file ${CF_BASE}/requirements_prod.txt\x1b[0m"
-            python -m pip install -r "${CF_BASE}/requirements_prod.txt" || ( rm -f "${pending_flag_file}" && return "14" )
+    # only continue outside remote jobs
+    if [ "${CF_REMOTE_JOB}" != "1" ]; then
+        # optionally remove the current installation
+        if [ "${mode}" = "reinstall" ]; then
+            echo "removing current installation at $install_path (mode '${mode}')"
+            rm -rf "${install_path}"
         fi
 
-        # install requirement files
-        for f in ${requirement_files[@]}; do
-            echo -e "\n\x1b[0;49;35minstalling requirement file ${f}\x1b[0m"
-            python -m pip install -r "${f}" || ( rm -f "${pending_flag_file}" && return "15" )
-            echo
-        done
-
-        # ensure that the venv is relocateable
-        cf_make_venv_relocateable "${CF_VENV_NAME}" || ( rm -f "${pending_flag_file}" && return "16" )
-
-        # write the version and a timestamp into the flag file
-        echo "version ${venv_version}" > "${CF_SANDBOX_FLAG_FILE}"
-        echo "timestamp $( date "+%s" )" >> "${CF_SANDBOX_FLAG_FILE}"
-        rm -f "${pending_flag_file}"
-    else
-        # get the current version
-        local curr_version="$( cat "${CF_SANDBOX_FLAG_FILE}" | grep -Po "version \K\d+.*" )"
-        if [ -z "${curr_version}" ]; then
-            >&2 echo "the flag file ${CF_SANDBOX_FLAG_FILE} does not contain a valid version"
-            return "20"
-        fi
-
-        # complain when the version is outdated
-        if [ "${curr_version}" != "${venv_version}" ] && [ "${versioncheck}" != "no" ]; then
-            if [ "${versioncheck}" != "warn" ]; then
-                ret="21"
+        # from here onwards, files and directories could be created and in order to prevent race
+        # conditions from multiple processes, guard the setup with the pending_flag_file and sleep for a
+        # random amount of seconds between 0 and 10 to further reduce the chance of simultaneously
+        # starting processes getting here at the same time
+        if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
+            local sleep_counter="0"
+            sleep "$( python3 -c 'import random;print(random.random() * 10)')"
+            # when the file is older than 30 minutes, consider it a dangling leftover from a
+            # previously failed installation attempt and delete it.
+            if [ -f "${pending_flag_file}" ]; then
+                local flag_file_age="$(( $( date +%s ) - $( date +%s -r "${pending_flag_file}" )))"
+                [ "${flag_file_age}" -ge "1800" ] && rm -f "${pending_flag_file}"
             fi
-            if [ "${versioncheck}" != "silent" ]; then
-                >&2 echo ""
-                >&2 echo "WARNING: outdated venv '${CF_VENV_NAME}' located at"
-                >&2 echo "WARNING: ${install_path}"
-                >&2 echo "WARNING: please consider updating it by adding 'reinstall' to the source command"
-                >&2 echo ""
+            # start the sleep loop
+            while [ -f "${pending_flag_file}" ]; do
+                # wait at most 15 minutes
+                sleep_counter="$(( $sleep_counter + 1 ))"
+                if [ "${sleep_counter}" -ge 180 ]; then
+                    >&2 echo "venv ${CF_VENV_NAME} is setup in different process, but number of sleeps exceeded"
+                    return "10"
+                fi
+                echo -e "\x1b[0;49;36mvenv ${CF_VENV_NAME} already being setup in different process, sleep ${sleep_counter} / 180\x1b[0m"
+                sleep 5
+            done
+        fi
+
+        # install or fetch when not existing
+        if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
+            echo
+            touch "${pending_flag_file}"
+            cf_color cyan "installing venv at ${install_path}"
+
+            rm -rf "${install_path}"
+            cf_create_venv "${CF_VENV_NAME}" || ( rm -f "${pending_flag_file}" && return "11" )
+
+            # activate it
+            source "${install_path}/bin/activate" "" || ( rm -f "${pending_flag_file}" && return "12" )
+
+            # update pip
+            cf_color magenta "updating pip"
+            python -m pip install -U pip || ( rm -f "${pending_flag_file}" && return "13" )
+
+            # install basic production requirements
+            if ! ${requirement_files_contains_prod}; then
+                cf_color magenta "installing requirement file ${CF_BASE}/requirements_prod.txt"
+                python -m pip install -r "${CF_BASE}/requirements_prod.txt" || ( rm -f "${pending_flag_file}" && return "14" )
+            fi
+
+            # install requirement files
+            for f in ${requirement_files[@]}; do
+                cf_color magenta "installing requirement file ${f}"
+                python -m pip install -r "${f}" || ( rm -f "${pending_flag_file}" && return "15" )
+                echo
+            done
+
+            # ensure that the venv is relocateable
+            cf_make_venv_relocateable "${CF_VENV_NAME}" || ( rm -f "${pending_flag_file}" && return "16" )
+
+            # write the version and a timestamp into the flag file
+            echo "version ${venv_version}" > "${CF_SANDBOX_FLAG_FILE}"
+            echo "timestamp $( date "+%s" )" >> "${CF_SANDBOX_FLAG_FILE}"
+            rm -f "${pending_flag_file}"
+        else
+            # get the current version
+            local curr_version="$( cat "${CF_SANDBOX_FLAG_FILE}" | grep -Po "version \K\d+.*" )"
+            if [ -z "${curr_version}" ]; then
+                >&2 echo "the flag file ${CF_SANDBOX_FLAG_FILE} does not contain a valid version"
+                return "20"
+            fi
+
+            # complain when the version is outdated
+            if [ "${curr_version}" != "${venv_version}" ] && [ "${versioncheck}" != "no" ]; then
+                if [ "${versioncheck}" != "warn" ]; then
+                    ret="21"
+                fi
+                if [ "${versioncheck}" != "silent" ]; then
+                    >&2 echo ""
+                    >&2 echo "WARNING: outdated venv '${CF_VENV_NAME}' located at"
+                    >&2 echo "WARNING: ${install_path}"
+                    >&2 echo "WARNING: please consider updating it by adding 'reinstall' to the source command"
+                    >&2 echo ""
+                fi
+            fi
+
+            # activate it
+            source "${install_path}/bin/activate" "" || return "$?"
+        fi
+    else
+        # in this case, the environment is inside a remote job, i.e., these variables are present:
+        # CF_JOB_BASH_SANDBOX_URIS, CF_JOB_BASH_SANDBOX_PATTERNS and CF_JOB_BASH_SANDBOX_NAMES
+        if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
+            # fetch the bundle and unpack it
+            echo "looking for bash sandbox bundle for venv ${CF_VENV_NAME}"
+            local sandbox_names=(${CF_JOB_BASH_SANDBOX_NAMES})
+            local sandbox_uris=(${CF_JOB_BASH_SANDBOX_URIS})
+            local sandbox_patterns=(${CF_JOB_BASH_SANDBOX_PATTERNS})
+            local found_sandbox="false"
+            for (( i=0; i<${#sandbox_names[@]}; i+=1 )); do
+                if [ "${sandbox_names[i]}" = "${CF_VENV_NAME}" ]; then
+                    echo "found bundle ${CF_VENV_NAME}, index ${i}, pattern ${sandbox_patterns[i]}, uri ${sandbox_uris[i]}"
+                    (
+                        mkdir -p "${install_path}" &&
+                        cd "${install_path}" &&
+                        law_wlcg_get_file "${sandbox_uris[i]}" "${sandbox_patterns[i]}" "bundle.tgz" &&
+                        tar -xzf "bundle.tgz"
+                    ) || return "$?"
+                    found_sandbox="true"
+                    break
+                fi
+            done
+            if ! ${found_sandbox}; then
+                >&2 echo "bash sandbox ${CF_VENV_BASE} not found in job configuration, stopping"
+                return "30"
             fi
         fi
 
         # activate it
         source "${install_path}/bin/activate" "" || return "$?"
+        echo
     fi
 
     # export variables

--- a/sandboxes/cf_dev.sh
+++ b/sandboxes/cf_dev.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/cf_prod.sh
+++ b/sandboxes/cf_prod.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/venv_columnar.sh
+++ b/sandboxes/venv_columnar.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/venv_columnar_dev.sh
+++ b/sandboxes/venv_columnar_dev.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/venv_docs_dev.sh
+++ b/sandboxes/venv_docs_dev.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/venv_ml_tf.sh
+++ b/sandboxes/venv_ml_tf.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 

--- a/sandboxes/venv_ml_tf_dev.sh
+++ b/sandboxes/venv_ml_tf_dev.sh
@@ -4,7 +4,7 @@
 # For more info on functionality and parameters, see the generic setup script _setup_venv.sh.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 


### PR DESCRIPTION
This PR refactors the main software stack underneath columnflow.

So far, we relied on the python installation present on the host system (mostly 3.6) as well as additional packages shipped with lcg setups via /cvmfs such as gfal and its bindings. This introduced some "side effects", most notably being strongly tied to the installed python version in all venvs and not being able to use latest packages (e.g. the newest matplotlib, mplhep, awkward, etc releases dropped python 3.6 support entirely).

In this PR, the base environment is shipped with columnflow and relies on miniconda with (at the moment) python 3.9. It is meant as a minimal layer to ensure a portable base system and not meant as a replacement for the virtual envs we use on top. Thus, the conda setup only provides an updated python, gfal2 + bindings and conda-pack (for creating a relocatable bundle to ship with remote jobs).

The main idea is to let columnflow install this stack once and then built virtual envs on top as before. However, now we have some benefits:

- More independence w.r.t. the host system.
- Future python upgrades become trivial.
- Compatibility with latest packages in venvs.
- Gfal updates become trivial, too. The latest version is noticeably faster!
- No need to use CMSSW sandboxes for plotting (https://github.com/uhh-cms/columnflow/issues/26).

The only code updates, besides a few really minor one-line changes, are related to software and sandbox bundling for remote jobs. The latter is now done on a per-sandbox basis which leads to more, but smaller remote job requirements.

### Note ❗️

Since the software stack changes drastically with this PR, one should perhaps start a fresh environment when testing/using the new setup.

