### PR TITLE
Update code style and venv requirements for Python 3.9.

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -4,7 +4,9 @@
 Object and event calibration tools.
 """
 
-from typing import Optional, Union, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
@@ -14,10 +16,10 @@ Calibrator = TaskArrayFunction.derive("Calibrator")
 
 
 def calibrator(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     bases=(),
     **kwargs,
-) -> Union[DerivableMeta, Callable]:
+) -> DerivableMeta | Callable:
     """
     Decorator for creating a new :py:class:`Calibrator` subclass with additional, optional *bases*
     and attaching the decorated function to it as ``call_func``. All additional *kwargs* are added

--- a/columnflow/calibration/jets.py
+++ b/columnflow/calibration/jets.py
@@ -5,7 +5,6 @@ Calibration methods for jets
 """
 
 import os
-from typing import Tuple
 
 import law
 
@@ -136,7 +135,7 @@ def prop_met(
     jet_phi2: ak.Array,
     met_pt1: ak.Array,
     met_phi1: ak.Array,
-) -> Tuple[ak.Array, ak.Array]:
+) -> tuple[ak.Array, ak.Array]:
     # avoid unwanted broadcasting
     assert jet_pt1.ndim == jet_phi1.ndim
     assert jet_pt2.ndim == jet_phi2.ndim

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -4,6 +4,8 @@
 Helpers and utilities for working with columnar libraries.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "mandatory_coffea_columns", "EMPTY_INT", "EMPTY_FLOAT",
     "Route", "RouteFilter", "ArrayFunction", "TaskArrayFunction", "ChunkedReader",
@@ -80,7 +82,7 @@ class RouteMeta(type):
     constructor.
     """
 
-    def __call__(cls, route: Optional[Union["Route", Any]] = None):
+    def __call__(cls, route: Route | Any | None = None):
         if isinstance(route, cls):
             return route
 
@@ -158,7 +160,7 @@ class Route(object, metaclass=RouteMeta):
     def _join(
         cls,
         sep: str,
-        fields: Sequence[Union[str, int, slice, type(Ellipsis), tuple, list]],
+        fields: Sequence[str | int | slice | type(Ellipsis) | tuple | list],
         _outer: bool = True,
     ) -> str:
         """
@@ -189,7 +191,7 @@ class Route(object, metaclass=RouteMeta):
     @classmethod
     def join(
         cls,
-        fields: Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]],
+        fields: Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> str:
         """
         Joins a sequence of strings into a string in dot format and returns it.
@@ -199,7 +201,7 @@ class Route(object, metaclass=RouteMeta):
     @classmethod
     def join_nano(
         cls,
-        fields: Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]],
+        fields: Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> str:
         """
         Joins a sequence of strings into a string in nano-style underscore format and returns it.
@@ -211,7 +213,7 @@ class Route(object, metaclass=RouteMeta):
         cls,
         sep: str,
         column: str,
-    ) -> Tuple[Union[str, int, slice, type(Ellipsis), list, tuple]]:
+    ) -> tuple[str | int | slice | type(Ellipsis) | list | tuple]:
         """
         Splits a string at a separator *sep* and returns the fragments, potentially with selection,
         slice and advanced indexing expressions.
@@ -264,7 +266,7 @@ class Route(object, metaclass=RouteMeta):
         return tuple(parts)
 
     @classmethod
-    def split(cls, column: str) -> Tuple[Union[str, int, slice, type(Ellipsis), list, tuple]]:
+    def split(cls, column: str) -> tuple[str | int | slice | type(Ellipsis) | list | tuple]:
         """
         Splits a string assumed to be in dot format and returns the fragments, potentially with
         selection, slice and advanced indexing expressions.
@@ -272,7 +274,7 @@ class Route(object, metaclass=RouteMeta):
         return cls._split(cls.DOT_SEP, column)
 
     @classmethod
-    def split_nano(cls, column: str) -> Tuple[Union[str, int, slice, type(Ellipsis), list, tuple]]:
+    def split_nano(cls, column: str) -> tuple[str | int | slice | type(Ellipsis) | list | tuple]:
         """
         Splits a string assumed to be in nano-style underscore format and returns the fragments,
         potentially with selection, slice and advanced indexing expressions.
@@ -290,15 +292,15 @@ class Route(object, metaclass=RouteMeta):
             self.add(route)
 
     @property
-    def fields(self):
+    def fields(self) -> tuple:
         return tuple(self._fields)
 
     @property
-    def column(self):
+    def column(self) -> str:
         return self.join(self._fields)
 
     @property
-    def nano_column(self):
+    def nano_column(self) -> str:
         return self.join_nano(self._fields)
 
     def __str__(self) -> str:
@@ -313,7 +315,7 @@ class Route(object, metaclass=RouteMeta):
     def __len__(self) -> int:
         return len(self._fields)
 
-    def __eq__(self, other: Union["Route", Sequence[str], str]) -> bool:
+    def __eq__(self, other: Route | Sequence[str] | str) -> bool:
         if isinstance(other, Route):
             return self.fields == other.fields
         elif isinstance(other, (list, tuple)):
@@ -330,7 +332,7 @@ class Route(object, metaclass=RouteMeta):
 
     def __add__(
         self,
-        other: Union["Route", str, Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]]],
+        other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> "Route":
         route = self.copy()
         route.add(other)
@@ -338,13 +340,13 @@ class Route(object, metaclass=RouteMeta):
 
     def __radd__(
         self,
-        other: Union["Route", str, Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]]],
+        other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> "Route":
         return self.__add__(other)
 
     def __iadd__(
         self,
-        other: Union["Route", str, Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]]],
+        other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> "Route":
         self.add(other)
         return self
@@ -352,7 +354,7 @@ class Route(object, metaclass=RouteMeta):
     def __getitem__(
         self,
         index: Any,
-    ) -> Union["Route", str, int, slice, type(Ellipsis), list, tuple]:
+    ) -> Route | str | int | slice | type(Ellipsis) | list | tuple:
         # detect slicing and return a new instance with the selected fields
         field = self._fields.__getitem__(index)
         return field if isinstance(index, int) else self.__class__(field)
@@ -360,13 +362,13 @@ class Route(object, metaclass=RouteMeta):
     def __setitem__(
         self,
         index: Any,
-        value: Union[str, int, slice, type(Ellipsis), list, tuple],
+        value: str | int | slice | type(Ellipsis) | list | tuple,
     ) -> None:
         self._fields.__setitem__(index, value)
 
     def add(
         self,
-        other: Union["Route", str, Sequence[Union[str, int, slice, type(Ellipsis), list, tuple]]],
+        other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
     ) -> None:
         """
         Adds an *other* route instance, or the fields extracted from either a sequence of strings or
@@ -394,7 +396,7 @@ class Route(object, metaclass=RouteMeta):
         """
         self._fields[:] = self._fields[::-1]
 
-    def copy(self) -> "Route":
+    def copy(self) -> Route:
         """
         Returns a copy if this instance.
         """
@@ -482,7 +484,7 @@ class Route(object, metaclass=RouteMeta):
 def get_ak_routes(
     ak_array: ak.Array,
     max_depth: int = 0,
-) -> List[Route]:
+) -> list[Route]:
     """
     Extracts all routes pointing to columns of a potentially deeply nested awkward array *ak_array*
     and returns them in a list of :py:class:`Route` instances. Example:
@@ -534,7 +536,7 @@ def get_ak_routes(
 
 def has_ak_column(
     ak_array: ak.Array,
-    route: Union[Route, Sequence[str], str],
+    route: Route | Sequence[str] | str,
 ) -> bool:
     """
     Returns whether an awkward array *ak_array* contains a nested field identified by a *route*. A
@@ -553,7 +555,7 @@ def has_ak_column(
 
 def set_ak_column(
     ak_array: ak.Array,
-    route: Union[Route, Sequence[str], str],
+    route: Route | Sequence[str] | str,
     value: ak.Array,
 ) -> ak.Array:
     """
@@ -633,7 +635,7 @@ def set_ak_column(
 
 def remove_ak_column(
     ak_array: ak.Array,
-    route: Union[Route, Sequence[str], str],
+    route: Route | Sequence[str] | str,
     silent: bool = False,
 ) -> ak.Array:
     """
@@ -680,8 +682,8 @@ def remove_ak_column(
 
 def add_ak_alias(
     ak_array: ak.Array,
-    src_route: Union[Route, Sequence[str], str],
-    dst_route: Union[Route, Sequence[str], str],
+    src_route: Route | Sequence[str] | str,
+    dst_route: Route | Sequence[str] | str,
     remove_src: bool = False,
 ) -> ak.Array:
     """
@@ -715,7 +717,7 @@ def add_ak_alias(
 
 def add_ak_aliases(
     ak_array: ak.Array,
-    aliases: Dict[Union[Route, Sequence[str], str], Union[Route, Sequence[str], str]],
+    aliases: dict[Route | Sequence[str] | str, Route | Sequence[str], str],
     remove_src: bool = False,
 ) -> ak.Array:
     """
@@ -739,9 +741,9 @@ def add_ak_aliases(
 def update_ak_array(
     ak_array: ak.Array,
     *others: ak.Array,
-    overwrite_routes: Union[bool, List[Union[Route, Sequence[str], str]]] = True,
-    add_routes: Union[bool, List[Union[Route, Sequence[str], str]]] = False,
-    concat_routes: Union[bool, List[Union[Route, Sequence[str], str]]] = False,
+    overwrite_routes: bool | list[Route | Sequence[str], str] = True,
+    add_routes: bool | list[Route | Sequence[str], str] = False,
+    concat_routes: bool | list[Route | Sequence[str], str] = False,
 ) -> ak.Array:
     """
     Updates an awkward array *ak_array* with the content of multiple different arrays *others* and
@@ -824,7 +826,7 @@ def update_ak_array(
 
 def flatten_ak_array(
     ak_array: ak.Array,
-    routes: Optional[Union[Sequence, set, Callable[[str], bool]]] = None,
+    routes: Sequence | set | Callable[[str], bool] | None = None,
 ) -> OrderedDict:
     """
     Flattens a nested awkward array *ak_array* into a dictionary that maps joined column names to
@@ -856,7 +858,7 @@ def flatten_ak_array(
 
 def sort_ak_fields(
     ak_array: ak.Array,
-    sort_fn: Optional[Callable[[str], int]] = None,
+    sort_fn: Callable[[str], int] | None = None,
 ) -> ak.Array:
     """
     Recursively sorts all fields of an awkward array *ak_array* and returns a new view. When a
@@ -931,8 +933,8 @@ def flat_np_view(ak_array: ak.Array, axis: int = 1) -> np.array:
 def attach_behavior(
     ak_array: ak.Array,
     type_name: str,
-    behavior: Optional[dict] = None,
-    skip_fields: Optional[Sequence[str]] = None,
+    behavior: dict | None = None,
+    skip_fields: Sequence[str] | None = None,
 ) -> ak.Array:
     """
     Attaches behavior of type *type_name* to an awkward array *ak_array* and returns it. *type_name*
@@ -995,13 +997,13 @@ class RouteFilter(object):
        instance.
     """
 
-    def __init__(self, keep_routes):
+    def __init__(self, keep_routes: Sequence[Route | str]):
         super().__init__()
 
         self.keep_routes = list(keep_routes)
         self.remove_routes = None
 
-    def __call__(self, ak_array):
+    def __call__(self, ak_array: ak.Array) -> ak.Array:
         # manually remove colums that should not be kept
         if self.remove_routes is None:
             # convert routes to keep into string columns for pattern checks
@@ -1186,9 +1188,9 @@ class ArrayFunction(Derivable):
 
     def __init__(
         self,
-        call_func: Optional[Callable] = law.no_value,
-        deferred_init: Optional[bool] = True,
-        instance_cache: Optional[dict] = None,
+        call_func: Callable | None = law.no_value,
+        deferred_init: bool | None = True,
+        instance_cache: dict | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -1231,7 +1233,7 @@ class ArrayFunction(Derivable):
         if deferred_init:
             self.deferred_init(instance_cache or {})
 
-    def __getitem__(self, dep_cls: DerivableMeta) -> "ArrayFunction":
+    def __getitem__(self, dep_cls: DerivableMeta) -> ArrayFunction:
         """
         Item access to dependencies.
         """
@@ -1283,13 +1285,13 @@ class ArrayFunction(Derivable):
             # save the updated set of dependencies
             setattr(self, f"{attr}_instances", deps)
 
-    def instantiate_dependency(self, cls: DerivableMeta, **kwargs: Any) -> "ArrayFunction":
+    def instantiate_dependency(self, cls: DerivableMeta, **kwargs: Any) -> ArrayFunction:
         """
         Controls the instantiation of a dependency given by its *cls* and arbitrary *kwargs*.
         """
         return cls(**kwargs)
 
-    def get_dependencies(self, include_others: bool = False) -> Set[Union["ArrayFunction", Any]]:
+    def get_dependencies(self, include_others: bool = False) -> set[ArrayFunction | Any]:
         """
         Returns a set of instances of all dependencies. When *include_others* is *True*, also
         non-ArrayFunction types are returned.
@@ -1307,7 +1309,7 @@ class ArrayFunction(Derivable):
 
         return deps
 
-    def _get_columns(self, io_flag: IOFlag, call_cache: Optional[set] = None) -> Set[str]:
+    def _get_columns(self, io_flag: IOFlag, call_cache: set | None = None) -> set[str]:
         if io_flag == self.IOFlag.AUTO:
             raise ValueError("io_flag in internal _get_columns method must not be AUTO")
 
@@ -1339,18 +1341,18 @@ class ArrayFunction(Derivable):
 
         return columns
 
-    def _get_used_columns(self, call_cache: Optional[set] = None) -> Set[str]:
+    def _get_used_columns(self, call_cache: set | None = None) -> set[str]:
         return self._get_columns(io_flag=self.IOFlag.USES, call_cache=call_cache)
 
     @property
-    def used_columns(self) -> Set[str]:
+    def used_columns(self) -> set[str]:
         return self._get_used_columns()
 
-    def _get_produced_columns(self, call_cache: Optional[set] = None) -> Set[str]:
+    def _get_produced_columns(self, call_cache: set | None = None) -> set[str]:
         return self._get_columns(io_flag=self.IOFlag.PRODUCES, call_cache=call_cache)
 
     @property
-    def produced_columns(self) -> Set[str]:
+    def produced_columns(self) -> set[str]:
         return self._get_produced_columns()
 
     def __call__(self, *args, **kwargs):
@@ -1544,12 +1546,12 @@ class TaskArrayFunction(ArrayFunction):
     def __init__(
         self,
         *args,
-        init_func: Optional[Callable] = law.no_value,
-        requires_func: Optional[Callable] = law.no_value,
-        setup_func: Optional[Callable] = law.no_value,
-        sandbox: Optional[str] = law.no_value,
-        call_force: Optional[bool] = law.no_value,
-        inst_dict: Optional[dict] = None,
+        init_func: Callable | None = law.no_value,
+        requires_func: Callable | None = law.no_value,
+        setup_func: Callable | None = law.no_value,
+        sandbox: str | None = law.no_value,
+        call_force: bool | None = law.no_value,
+        inst_dict: dict | None = None,
         **kwargs,
     ):
         # store the inst dict with arbitrary attributes that are forwarded to dependency creation
@@ -1605,7 +1607,7 @@ class TaskArrayFunction(ArrayFunction):
         # call super, which instantiates the dependencies
         super().deferred_init(instance_cache)
 
-    def instantiate_dependency(self, cls: DerivableMeta, **kwargs: Any) -> "TaskArrayFunction":
+    def instantiate_dependency(self, cls: DerivableMeta, **kwargs: Any) -> TaskArrayFunction:
         """
         Controls the instantiation of a dependency given by its *cls* and arbitrary *kwargs*,
         updated by *this* instances :py:attr:`inst_dict`.
@@ -1616,7 +1618,7 @@ class TaskArrayFunction(ArrayFunction):
 
         return super().instantiate_dependency(cls, **kwargs)
 
-    def _get_all_shifts(self, call_cache: Optional[set] = None) -> Set[str]:
+    def _get_all_shifts(self, call_cache: set | None = None) -> set[str]:
         shifts = set()
 
         # init the call cache
@@ -1638,13 +1640,13 @@ class TaskArrayFunction(ArrayFunction):
         return shifts
 
     @property
-    def all_shifts(self) -> Set[str]:
+    def all_shifts(self) -> set[str]:
         return self._get_all_shifts()
 
     def run_requires(
         self,
-        reqs: Optional[dict] = None,
-        call_cache: Optional[set] = None,
+        reqs: dict | None = None,
+        call_cache: set | None = None,
     ) -> dict:
         """
         Recursively runs the :py:meth:`requires_func` of this instance and all dependencies. *reqs*
@@ -1674,7 +1676,7 @@ class TaskArrayFunction(ArrayFunction):
         self,
         reqs: dict,
         inputs: dict,
-        call_cache: Optional[set] = None,
+        call_cache: set | None = None,
     ) -> None:
         """
         Recursively runs the :py:meth:`setup_func` of this instance and all dependencies. *reqs*
@@ -1698,8 +1700,8 @@ class TaskArrayFunction(ArrayFunction):
     def __call__(
         self,
         *args,
-        call_cache: Optional[Union[bool, defaultdict]] = None,
-        call_force: Optional[bool] = None,
+        call_cache: bool | defaultdict | None = None,
+        call_force: bool | None = None,
         n_return: int = 1,
         **kwargs,
     ) -> Any:
@@ -1821,12 +1823,12 @@ class ChunkedReader(object):
     def __init__(
         self,
         source: Any,
-        source_type: Optional[Union[str, List[str]]] = None,
+        source_type: str | Sequence[str] | None = None,
         chunk_size: int = int(os.getenv("CF_CHUNKED_READER_CHUNK_SIZE", 50000)),
         pool_size: int = int(os.getenv("CF_CHUNKED_READER_POOL_SIZE", 4)),
-        lazy: Union[bool, List[bool]] = False,
-        open_options: Optional[Union[dict, List[dict]]] = None,
-        read_options: Optional[Union[dict, List[dict]]] = None,
+        lazy: bool | Sequence[bool] = False,
+        open_options: dict | list[dict] | None = None,
+        read_options: dict | list[dict] | None = None,
         iter_message: str = "handling chunk {pos.index}",
     ):
         super().__init__()
@@ -1907,9 +1909,9 @@ class ChunkedReader(object):
     @classmethod
     def get_source_handlers(
         cls,
-        source_type: Optional[str],
-        source: Optional[Any],
-    ) -> Tuple[str, Callable, Callable]:
+        source_type: str | None,
+        source: Any | None,
+    ) -> tuple[str, Callable, Callable]:
         """
         Takes a *source_type* (see list below) and gathers information about how to open and read
         content from a specific source. A 3-tuple *(source type, open function, read function)* is
@@ -1956,9 +1958,9 @@ class ChunkedReader(object):
     def open_awkward_parquet(
         cls,
         source: str,
-        open_options: Optional[dict] = None,
-        file_cache: Optional[list] = None,
-    ) -> Tuple[ak.Array, int]:
+        open_options: dict | None = None,
+        file_cache: list | None = None,
+    ) -> tuple[ak.Array, int]:
         """
         Opens a parquet file saved at *source*, loads the content as an awkward array and returns a
         2-tuple *(array, length)*. *open_options* are forwarded to ``awkward.from_parquet``. Passing
@@ -1967,10 +1969,11 @@ class ChunkedReader(object):
         if not isinstance(source, str):
             raise Exception(f"'{source}' cannot be opened as awkward_parquet")
 
-        # prepare open options
+        # default open options
         open_options = open_options or {}
         open_options["lazy"] = True
         open_options["lazy_cache"] = None
+        open_options["use_threads"] = False
 
         # load the array
         arr = ak.from_parquet(source, **open_options)
@@ -1980,15 +1983,15 @@ class ChunkedReader(object):
     @classmethod
     def open_uproot_root(
         cls,
-        source: Union[
-            str,
-            uproot.ReadOnlyDirectory,
-            Tuple[str, str],
-            Tuple[uproot.ReadOnlyDirectory, str],
-        ],
-        open_options: Optional[dict] = None,
-        file_cache: Optional[list] = None,
-    ) -> Tuple[uproot.TTree, int]:
+        source: (
+            str |
+            uproot.ReadOnlyDirectory |
+            tuple[str, str] |
+            tuple[uproot.ReadOnlyDirectory, str]
+        ),
+        open_options: dict | None = None,
+        file_cache: list | None = None,
+    ) -> tuple[uproot.TTree, int]:
         """
         Opens an uproot tree from a root file at *source* and returns a 2-tuple *(tree, entries)*.
         *source* can be the path of the file, an already opened, readable uproot file (assuming the
@@ -2014,15 +2017,15 @@ class ChunkedReader(object):
     @classmethod
     def open_coffea_root(
         cls,
-        source: Union[
-            str,
-            uproot.ReadOnlyDirectory,
-            Tuple[str, str],
-            Tuple[uproot.ReadOnlyDirectory, str],
-        ],
-        open_options: Optional[dict] = None,
-        file_cache: Optional[list] = None,
-    ) -> Tuple[uproot.ReadOnlyDirectory, int]:
+        source: (
+            str |
+            uproot.ReadOnlyDirectory |
+            tuple[str, str] |
+            tuple[uproot.ReadOnlyDirectory, str]
+        ),
+        open_options: dict | None = None,
+        file_cache: list | None = None,
+    ) -> tuple[uproot.ReadOnlyDirectory, int]:
         """
         Opens an uproot file at *source* for subsequent processing with coffea and returns a 2-tuple
         *(uproot file, tree entries)*. *source* can be the path of the file, an already opened,
@@ -2049,9 +2052,9 @@ class ChunkedReader(object):
     def open_coffea_parquet(
         cls,
         source: str,
-        open_options: Optional[dict] = None,
-        file_cache: Optional[list] = None,
-    ) -> Tuple[str, int]:
+        open_options: dict | None = None,
+        file_cache: list | None = None,
+    ) -> tuple[str, int]:
         """
         Given a parquet file located at *source*, returns a 2-tuple *(source, entries)*. Passing
         *open_options* and or *file_cache* has no effect.
@@ -2064,8 +2067,8 @@ class ChunkedReader(object):
         source_object: ak.Array,
         chunk_pos: ChunkPosition,
         lazy: bool = False,
-        read_options: Optional[dict] = None,
-    ):
+        read_options: dict | None = None,
+    ) -> ak.Array:
         """
         Given an awkward array *source_object*, returns the chunk referred to by *chunk_pos* either
         as a lazy slice if *lazy* is *True*, or as a full copy loaded into memory otherwise. Passing
@@ -2080,7 +2083,7 @@ class ChunkedReader(object):
         source_object: uproot.TTree,
         chunk_pos: ChunkPosition,
         lazy: bool = False,
-        read_options: Optional[dict] = None,
+        read_options: dict | None = None,
     ) -> ak.Array:
         """
         Given an uproot TTree *source_object*, returns an awkward array chunk referred to by
@@ -2102,10 +2105,10 @@ class ChunkedReader(object):
     @classmethod
     def read_coffea_root(
         cls,
-        source_object: Union[str, uproot.ReadOnlyDirectory],
+        source_object: str | uproot.ReadOnlyDirectory,
         chunk_pos: ChunkPosition,
         lazy: bool = False,
-        read_options: Optional[dict] = None,
+        read_options: dict | None = None,
     ) -> coffea.nanoevents.methods.base.NanoEventsArray:
         """
         Given a file location or opened uproot file *source_object*, returns an awkward array chunk
@@ -2133,7 +2136,7 @@ class ChunkedReader(object):
         source_object: str,
         chunk_pos: ChunkPosition,
         lazy: bool = False,
-        read_options: Optional[dict] = None,
+        read_options: dict | None = None,
     ) -> coffea.nanoevents.methods.base.NanoEventsArray:
         """
         Given a the location of a parquet file *source_object*, returns an awkward array chunk
@@ -2222,7 +2225,7 @@ class ChunkedReader(object):
         self,
         func: Callable,
         args: tuple = (),
-        kwargs: Optional[dict] = None,
+        kwargs: dict | None = None,
         where: int = 0,
     ) -> None:
         """

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -15,7 +15,6 @@ __all__ = [
     "sorted_ak_to_parquet", "flat_np_view", "attach_behavior",
 ]
 
-
 import os
 import re
 import math
@@ -27,7 +26,7 @@ import multiprocessing
 import multiprocessing.pool
 from functools import partial
 from collections import namedtuple, OrderedDict, defaultdict
-from typing import Optional, Union, Sequence, Set, Tuple, List, Dict, Callable, Any
+from typing import Sequence, Callable, Any
 
 import law
 

--- a/columnflow/example_config/analysis_st.py
+++ b/columnflow/example_config/analysis_st.py
@@ -5,7 +5,6 @@ Configuration of the single top analysis.
 """
 
 import re
-from typing import Set
 
 from scinum import Number, REL
 from order import Analysis, Shift
@@ -111,7 +110,7 @@ config_2018.set_aux("minbiasxs", Number(69.2, (REL, 0.046)))
 
 
 # helper to add column aliases for both shifts of a source
-def add_aliases(shift_source: str, aliases: Set[str], selection_dependent: bool):
+def add_aliases(shift_source: str, aliases: set[str], selection_dependent: bool):
     for direction in ["up", "down"]:
         shift = config_2018.get_shift(Shift.join_name(shift_source, direction))
         # format keys and values

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -4,9 +4,11 @@
 Basic objects for defining statistical inference models.
 """
 
+from __future__ import annotations
+
 import enum
 import copy as _copy
-from typing import Optional, Tuple, List, Union, Dict, Generator, Callable, TextIO, Sequence, Any
+from typing import Generator, Callable, TextIO, Sequence, Any
 
 import law
 import order as od
@@ -218,11 +220,11 @@ class InferenceModel(Derivable):
     def category_spec(
         cls,
         name: str,
-        category: Optional[str] = None,
-        variable: Optional[str] = None,
-        data_datasets: Optional[Sequence[str]] = None,
-        data_from_processes: Optional[Sequence[str]] = None,
-        mc_stats: Optional[Union[float, tuple]] = None,
+        category: str | None = None,
+        variable: str | None = None,
+        data_datasets: Sequence[str] | None = None,
+        data_from_processes: Sequence[str] | None = None,
+        mc_stats: float | tuple | None = None,
     ) -> DotDict:
         """
         Returns a dictionary representing a category (interchangeably called bin or channel in other
@@ -252,9 +254,9 @@ class InferenceModel(Derivable):
     def process_spec(
         cls,
         name: str,
-        process: Optional[str] = None,
+        process: str | None = None,
         signal: bool = False,
-        mc_datasets: Optional[Sequence[str]] = None,
+        mc_datasets: Sequence[str] | None = None,
     ) -> DotDict:
         """
         Returns a dictionary representing a process, forwarding all arguments.
@@ -277,10 +279,10 @@ class InferenceModel(Derivable):
     def parameter_spec(
         cls,
         name: str,
-        type: Union[ParameterType, str],
-        transformations: Sequence[Union[ParameterTransformation, str]] = (ParameterTransformation.none,),
-        shift_source: Optional[str] = None,
-        effect: Union[Any] = 1.0,
+        type: ParameterType | str,
+        transformations: Sequence[ParameterTransformation | str] = (ParameterTransformation.none,),
+        shift_source: str | None = None,
+        effect: Any | None = 1.0,
     ) -> DotDict:
         """
         Returns a dictionary representing a (nuisance) parameter, forwarding all arguments.
@@ -306,7 +308,7 @@ class InferenceModel(Derivable):
     def parameter_group_spec(
         cls,
         name: str,
-        parameter_names: Optional[Sequence[str]] = None,
+        parameter_names: Sequence[str] | None = None,
     ) -> DotDict:
         """
         Returns a dictionary representing a group of parameter names.
@@ -358,7 +360,7 @@ class InferenceModel(Derivable):
         if callable(self.init_func):
             self.init_func()
 
-    def to_yaml(self, stream: Optional[TextIO] = None) -> Union[None, str]:
+    def to_yaml(self, stream: TextIO | None = None) -> str | None:
         """
         Writes the content of the :py:attr:`model` into a file-like object *stream* when given, and
         returns a string representation otherwise.
@@ -389,9 +391,9 @@ class InferenceModel(Derivable):
 
     def get_categories(
         self,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        category: str | Sequence[str] | None = None,
         only_names: bool = False,
-    ) -> List[Union[DotDict, str]]:
+    ) -> list[DotDict | str]:
         """
         Returns a list of categories whose name match *category*. *category* can be a string, a
         pattern, or sequence of them. When *only_names* is *True*, only names of categories are
@@ -409,10 +411,10 @@ class InferenceModel(Derivable):
 
     def get_category(
         self,
-        category: Union[str, Sequence[str]],
+        category: str | Sequence[str],
         only_name: bool = False,
         silent: bool = False,
-    ) -> Union[DotDict, str]:
+    ) -> DotDict | str:
         """
         Returns a single category whose name matches *category*. *category* can be a string, a
         pattern, or sequence of them. An exception is raised if no or more than one category is
@@ -438,7 +440,7 @@ class InferenceModel(Derivable):
 
     def has_category(
         self,
-        category: Union[str, Sequence[str]],
+        category: str | Sequence[str],
     ) -> bool:
         """
         Returns *True* if a category whose name matches *category* is existing, and *False*
@@ -468,7 +470,7 @@ class InferenceModel(Derivable):
 
     def remove_category(
         self,
-        category: Union[str, Sequence[str]],
+        category: str | Sequence[str],
     ) -> bool:
         """
         Removes one or more categories whose names match *category*. Returns *True* if at least one
@@ -499,11 +501,11 @@ class InferenceModel(Derivable):
 
     def get_processes(
         self,
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
         only_names: bool = False,
         flat: bool = False,
-    ) -> Union[Dict[str, Union[DotDict, str]], List[str]]:
+    ) -> dict[str, DotDict | str] | list[str]:
         """
         Returns a dictionary of processes whose names match *process*, mapped to the name of the
         category they belong to. Categories can optionally be filtered through *category*. Both
@@ -545,11 +547,11 @@ class InferenceModel(Derivable):
 
     def get_process(
         self,
-        process: Union[str, Sequence[str]],
-        category: Optional[Union[str, Sequence[str]]] = None,
+        process: str | Sequence[str],
+        category: str | Sequence[str] | None = None,
         only_name: bool = False,
         silent: bool = False,
-    ) -> Union[DotDict, str]:
+    ) -> DotDict | str:
         """
         Returns a single process whose name matches *process*, and optionally, whose category's name
         matches *category*. Both *process* and *category* can be a string, a pattern, or sequence of
@@ -598,8 +600,8 @@ class InferenceModel(Derivable):
 
     def has_process(
         self,
-        process: Union[str, Sequence[str]],
-        category: Optional[Union[str, Sequence[str]]] = None,
+        process: str | Sequence[str],
+        category: str | Sequence[str] | None = None,
     ) -> bool:
         """
         Returns *True* if a process whose name matches *process*, and optionally whose category's
@@ -616,7 +618,7 @@ class InferenceModel(Derivable):
     def add_process(
         self,
         *args,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        category: str | Sequence[str] | None = None,
         silent: bool = False,
         **kwargs,
     ) -> None:
@@ -654,8 +656,8 @@ class InferenceModel(Derivable):
 
     def remove_process(
         self,
-        process: Union[str, Sequence[str]],
-        category: Optional[Union[str, Sequence[str]]] = None,
+        process: str | Sequence[str],
+        category: str | Sequence[str] | None = None,
     ) -> bool:
         """
         Removes one or more processes whose names match *process*, and optionally whose category's
@@ -692,12 +694,12 @@ class InferenceModel(Derivable):
 
     def get_parameters(
         self,
-        parameter: Optional[Union[str, Sequence[str]]] = None,
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str] | None = None,
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
         only_names: bool = False,
         flat: bool = False,
-    ) -> Union[Dict[str, Dict[str, Union[DotDict, str]]], List[str]]:
+    ) -> dict[str, dict[str, DotDict | str]] | list[str]:
         """
         Returns a dictionary of parameter whose names match *parameter*, mapped twice to the name of
         the category and the name of the process they belong to. Categories and processes can
@@ -748,12 +750,12 @@ class InferenceModel(Derivable):
 
     def get_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
         only_name: bool = False,
         silent: bool = False,
-    ) -> Union[DotDict, str]:
+    ) -> DotDict | str:
         """
         Returns a single parameter whose name matches *parameter*, and optionally, whose category's
         and process' name matches *category* and *process*. All three, *parameter*, *process* and
@@ -816,9 +818,9 @@ class InferenceModel(Derivable):
 
     def has_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
     ) -> bool:
         """
         Returns *True* if a parameter whose name matches *parameter*, and optionally whose
@@ -841,8 +843,8 @@ class InferenceModel(Derivable):
     def add_parameter(
         self,
         *args,
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
         **kwargs,
     ) -> DotDict:
         """
@@ -881,9 +883,9 @@ class InferenceModel(Derivable):
 
     def remove_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
     ) -> bool:
         """
         Removes one or more parameters whose names match *parameter*, and optionally whose
@@ -923,9 +925,9 @@ class InferenceModel(Derivable):
 
     def get_parameter_groups(
         self,
-        group: Optional[Union[str, Sequence[str]]] = None,
+        group: str | Sequence[str] | None = None,
         only_names: bool = False,
-    ) -> List[Union[DotDict, str]]:
+    ) -> list[DotDict | str]:
         """
         Returns a list of parameter group whose name match *group*. *group* can be a string, a
         pattern, or sequence of them.
@@ -945,9 +947,9 @@ class InferenceModel(Derivable):
 
     def get_parameter_group(
         self,
-        group: Union[str, Sequence[str]],
+        group: str | Sequence[str],
         only_name: bool = False,
-    ) -> Union[DotDict, str]:
+    ) -> DotDict | str:
         """
         Returns a single parameter group whose name matches *group*. *group* can be a string, a
         pattern, or sequence of them.
@@ -971,7 +973,7 @@ class InferenceModel(Derivable):
 
     def has_parameter_group(
         self,
-        group: Union[str, Sequence[str]],
+        group: str | Sequence[str],
     ) -> bool:
         """
         Returns *True* if a parameter group whose name matches *group* is existing, and *False*
@@ -1000,7 +1002,7 @@ class InferenceModel(Derivable):
 
     def remove_parameter_group(
         self,
-        group: Union[str, Sequence[str]],
+        group: str | Sequence[str],
     ) -> bool:
         """
         Removes one or more parameter groups whose names match *group*. *group* can be a string, a
@@ -1023,8 +1025,8 @@ class InferenceModel(Derivable):
 
     def add_parameter_to_group(
         self,
-        parameter: Union[str, Sequence[str]],
-        group: Union[str, Sequence[str]],
+        parameter: str | Sequence[str],
+        group: str | Sequence[str],
     ) -> bool:
         """
         Adds a parameter named *parameter* to one or multiple parameter groups whose name match
@@ -1062,8 +1064,8 @@ class InferenceModel(Derivable):
 
     def remove_parameter_from_groups(
         self,
-        parameter: Union[str, Sequence[str]],
-        group: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        group: str | Sequence[str] | None = None,
     ) -> bool:
         """
         Removes all parameters matching *parameter* from parameter groups whose names match *group*.
@@ -1098,8 +1100,8 @@ class InferenceModel(Derivable):
 
     def get_categories_with_process(
         self,
-        process: Union[str, Sequence[str]],
-    ) -> List[str]:
+        process: str | Sequence[str],
+    ) -> list[str]:
         """
         Returns a flat list of category names that contain processes matching *process*. *process*
         can be a string, a pattern, or sequence of them.
@@ -1112,10 +1114,10 @@ class InferenceModel(Derivable):
 
     def get_processes_with_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-        category: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        category: str | Sequence[str] | None = None,
         flat: bool = True,
-    ) -> Union[List[str], Dict[str, List[str]]]:
+    ) -> list[str] | dict[str, list[str]]:
         """
         Returns a dictionary of names of processes that contain a parameter whose names match
         *parameter*, mapped to categories names. Categories can optionally be filtered through
@@ -1147,10 +1149,10 @@ class InferenceModel(Derivable):
 
     def get_categories_with_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-        process: Optional[Union[str, Sequence[str]]] = None,
+        parameter: str | Sequence[str],
+        process: str | Sequence[str] | None = None,
         flat: bool = True,
-    ) -> Union[List[str], Dict[str, List[str]]]:
+    ) -> list[str] | dict[str, list[str]]:
         """
         Returns a dictionary of category names mapping to process names that contain parameters
         whose name match *parameter*. Processes can optionally be filtered through *process*. Both
@@ -1182,8 +1184,8 @@ class InferenceModel(Derivable):
 
     def get_groups_with_parameter(
         self,
-        parameter: Union[str, Sequence[str]],
-    ) -> List[str]:
+        parameter: str | Sequence[str],
+    ) -> list[str]:
         """
         Returns a list of names of parameter groups that contain a parameter whose name matches
         *parameter*, which can be a string, a pattern, or sequence of them.
@@ -1254,9 +1256,9 @@ class InferenceModel(Derivable):
 
     def iter_processes(
         self,
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
-    ) -> Generator[Tuple[DotDict, DotDict], None, None]:
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
+    ) -> Generator[tuple[DotDict, DotDict], None, None]:
         """
         Generator that iteratively yields all processes whose names match *process*, optionally
         in all categories whose names match *category*. The yielded value is a 2-tuple containing
@@ -1269,10 +1271,10 @@ class InferenceModel(Derivable):
 
     def iter_parameters(
         self,
-        parameter: Optional[Union[str, Sequence[str]]] = None,
-        process: Optional[Union[str, Sequence[str]]] = None,
-        category: Optional[Union[str, Sequence[str]]] = None,
-    ) -> Generator[Tuple[DotDict, DotDict, DotDict], None, None]:
+        parameter: str | Sequence[str] | None = None,
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
+    ) -> Generator[tuple[DotDict, DotDict, DotDict], None, None]:
         """
         Generator that iteratively yields all parameters whose names match *parameter*, optionally
         in all processes and categories whose names match *process* and *category*. The yielded
@@ -1286,10 +1288,10 @@ class InferenceModel(Derivable):
 
 
 def inference_model(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     bases=(),
     **kwargs,
-) -> Union[DerivableMeta, Callable]:
+) -> DerivableMeta | Callable:
     """
     Decorator for creating a new :py:class:`InferenceModel` subclass with additional, optional
     *bases* and attaching the decorated function to it as ``init_func``. All additional *kwargs* are

--- a/columnflow/inference/datacard.py
+++ b/columnflow/inference/datacard.py
@@ -4,9 +4,11 @@
 Helpers to write and work with datacards.
 """
 
+from __future__ import annotations
+
 import os
 from collections import OrderedDict
-from typing import Optional, Dict, Tuple, List, Sequence, Any
+from typing import Sequence, Any
 
 import law
 
@@ -41,7 +43,7 @@ class DatacardWriter(object):
     def __init__(
         self,
         inference_model_inst: InferenceModel,
-        histograms: Dict[str, Dict[str, Dict[str, hist.Hist]]],
+        histograms: dict[str, dict[str, dict[str, hist.Hist]]],
         rate_precision: int = 4,
         parameter_precision: int = 4,
     ):
@@ -57,7 +59,7 @@ class DatacardWriter(object):
         self,
         datacard_path: str,
         shapes_path: str,
-        shapes_path_ref: Optional[str] = None,
+        shapes_path_ref: str | None = None,
     ) -> None:
         """
         Writes the datacard into *datacard_path* with shapes saved in *shapes_path*. When the paths
@@ -307,9 +309,9 @@ class DatacardWriter(object):
         self,
         shapes_path: str,
         fill_empty_bins: float = 1e-5,
-    ) -> Tuple[
-        Dict[str, Dict[str, float]],
-        Dict[str, Dict[str, Dict[str, Tuple[float, float]]]],
+    ) -> tuple[
+        dict[str, dict[str, float]],
+        dict[str, dict[str, dict[str, tuple[float, float]]]],
         str,
         str,
     ]:
@@ -494,7 +496,7 @@ class DatacardWriter(object):
     def align_lines(
         cls,
         lines: Sequence[Any],
-    ) -> List[str]:
+    ) -> list[str]:
         lines = [
             (line.split() if isinstance(line, str) else list(map(str, law.util.flatten(line))))
             for line in lines
@@ -528,7 +530,7 @@ class DatacardWriter(object):
         cls,
         rates: Sequence[Any],
         parameters: Sequence[Any],
-    ) -> Tuple[List[str], List[str]]:
+    ) -> tuple[list[str], list[str]]:
         rates, parameters = [
             [
                 (line.split() if isinstance(line, str) else list(map(str, law.util.flatten(line))))

--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -4,8 +4,10 @@
 Definition of basic objects for describing and creating ML models.
 """
 
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Optional, Union, List, Tuple, Any, Set
+from typing import Any
 
 import law
 import order as od
@@ -76,7 +78,7 @@ class MLModel(Derivable):
         self,
         config_inst: od.Config,
         *,
-        parameters: Optional[OrderedDict] = None,
+        parameters: OrderedDict | None = None,
     ):
         super().__init__()
 
@@ -115,7 +117,7 @@ class MLModel(Derivable):
             for name, value in self.parameter_pairs(only_significant=True)
         )
 
-    def parameter_pairs(self, only_significant: bool = False) -> List[Tuple[str, Any]]:
+    def parameter_pairs(self, only_significant: bool = False) -> list[tuple[str, Any]]:
         """
         Returns a list of all parameter name-value tuples. In this context, significant parameters
         are those that potentially lead to different results (e.g. network architecture parameters
@@ -124,19 +126,19 @@ class MLModel(Derivable):
         return list(self.parameters.items())
 
     @property
-    def used_datasets(self) -> Set[od.Dataset]:
+    def used_datasets(self) -> set[od.Dataset]:
         if self._used_datasets is None:
             self._used_datasets = set(self.datasets())
         return self._used_datasets
 
     @property
-    def used_columns(self) -> Set[Union[Route, str]]:
+    def used_columns(self) -> set[Route | str]:
         if self._used_columns is None:
             self._used_columns = set(self.uses())
         return self._used_columns
 
     @property
-    def produced_columns(self) -> Set[Union[Route, str]]:
+    def produced_columns(self) -> set[Route | str]:
         if self._produced_columns is None:
             self._produced_columns = set(self.produces())
         return self._produced_columns
@@ -148,19 +150,19 @@ class MLModel(Derivable):
         """
         raise NotImplementedError()
 
-    def datasets(self) -> Set[od.Dataset]:
+    def datasets(self) -> set[od.Dataset]:
         """
         Returns a set of all required datasets. To be implemented in subclasses.
         """
         raise NotImplementedError()
 
-    def uses(self) -> Set[Union[Route, str]]:
+    def uses(self) -> set[Route | str]:
         """
         Returns a set of all required columns. To be implemented in subclasses.
         """
         raise NotImplementedError()
 
-    def produces(self) -> Set[Union[Route, str]]:
+    def produces(self) -> set[Route | str]:
         """
         Returns a set of all produced columns. To be implemented in subclasses.
         """
@@ -195,7 +197,7 @@ class MLModel(Derivable):
         self,
         task: law.Task,
         events: ak.Array,
-        models: List[Any],
+        models: list[Any],
         fold_indices: ak.Array,
         events_used_in_training: bool = False,
     ) -> ak.Array:

--- a/columnflow/ml/example.py
+++ b/columnflow/ml/example.py
@@ -4,7 +4,9 @@
 Exemplary ML model.
 """
 
-from typing import List, Any, Set, Union, Optional
+from __future__ import annotations
+
+from typing import Any
 
 import law
 import order as od
@@ -19,7 +21,7 @@ tf = maybe_import("tensorflow")
 
 class ExampleModel(MLModel):
 
-    def __init__(self, *args, folds: Optional[int] = None, **kwargs):
+    def __init__(self, *args, folds: int | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
         # class- to instance-level attributes
@@ -44,16 +46,16 @@ class ExampleModel(MLModel):
     def sandbox(self, task: law.Task) -> str:
         return dev_sandbox("bash::$CF_BASE/sandboxes/venv_ml_tf.sh")
 
-    def datasets(self) -> Set[od.Dataset]:
+    def datasets(self) -> set[od.Dataset]:
         return {
             self.config_inst.get_dataset("st_tchannel_t"),
             self.config_inst.get_dataset("tt_sl"),
         }
 
-    def uses(self) -> Set[Union[Route, str]]:
+    def uses(self) -> set[Route | str]:
         return {"ht", "n_jet", "n_muon", "n_electron", "normalization_weight"}
 
-    def produces(self) -> Set[Union[Route, str]]:
+    def produces(self) -> set[Route | str]:
         return {f"{self.cls_name}.n_muon", f"{self.cls_name}.n_electron"}
 
     def output(self, task: law.Task) -> law.FileSystemDirectoryTarget:
@@ -82,7 +84,7 @@ class ExampleModel(MLModel):
         self,
         task: law.Task,
         events: ak.Array,
-        models: List[Any],
+        models: list[Any],
         fold_indices: ak.Array,
         events_used_in_training: bool = False,
     ) -> ak.Array:

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -4,8 +4,10 @@
 Example plot functions.
 """
 
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Sequence, Optional
+from typing import Sequence
 
 import law
 
@@ -221,10 +223,10 @@ def plot_variable_per_process(
     hists: OrderedDict,
     config_inst: od.config,
     variable_inst: od.variable,
-    style_config: Optional[dict] = None,
-    shape_norm: Optional[bool] = False,
-    yscale: Optional[str] = "",
-    process_settings: Optional[dict] = None,
+    style_config: dict | None = None,
+    shape_norm: bool | None = False,
+    yscale: str | None = "",
+    process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
 
@@ -335,9 +337,9 @@ def plot_variable_variants(
     hists: OrderedDict,
     config_inst: od.config,
     variable_inst: od.variable,
-    style_config: Optional[dict] = None,
+    style_config: dict | None = None,
     shape_norm: bool = False,
-    yscale: Optional[str] = None,
+    yscale: str | None = None,
     **kwargs,
 ) -> plt.Figure:
     plot_config = OrderedDict()
@@ -388,11 +390,11 @@ def plot_shifted_variable(
     hists: Sequence[hist.Hist],
     config_inst: od.config,
     variable_inst: od.variable,
-    style_config: Optional[dict] = None,
+    style_config: dict | None = None,
     shape_norm: bool = False,
-    yscale: Optional[str] = None,
-    legend_title: Optional[str] = None,
-    process_settings: Optional[dict] = None,
+    yscale: str | None = None,
+    legend_title: str | None = None,
+    process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     # create the sum of histograms over all processes
@@ -474,10 +476,10 @@ def plot_shifted_variable(
 def plot_cutflow(
     hists: OrderedDict,
     config_inst: od.config,
-    style_config: Optional[dict] = None,
+    style_config: dict | None = None,
     shape_norm: bool = False,
-    yscale: Optional[str] = None,
-    process_settings: Optional[dict] = None,
+    yscale: str | None = None,
+    process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     if not process_settings:

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -4,7 +4,9 @@
 Tools for producing new array columns (e.g. high-level variables).
 """
 
-from typing import Optional, Union, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
@@ -14,10 +16,10 @@ Producer = TaskArrayFunction.derive("Producer")
 
 
 def producer(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     bases=(),
     **kwargs,
-) -> Union[DerivableMeta, Callable]:
+) -> DerivableMeta | Callable:
     """
     Decorator for creating a new :py:class:`Producer` subclass with additional, optional *bases* and
     attaching the decorated function to it as ``call_func``. All additional *kwargs* are added as

--- a/columnflow/production/util.py
+++ b/columnflow/production/util.py
@@ -4,7 +4,9 @@
 General producers that might be utilized in various places.
 """
 
-from typing import Optional, Union, Sequence
+from __future__ import annotations
+
+from typing import Sequence
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
@@ -62,7 +64,7 @@ default_collections = {
 def attach_coffea_behavior(
     self: Producer,
     events: ak.Array,
-    collections: Optional[Union[dict, Sequence]] = None,
+    collections: dict | Sequence | None = None,
     **kwargs,
 ) -> ak.Array:
     """

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -4,7 +4,9 @@
 Object and event selection tools.
 """
 
-from typing import Optional, Union, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 import law
 import order as od
@@ -29,10 +31,10 @@ class Selector(TaskArrayFunction):
 
 
 def selector(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     bases=(),
     **kwargs,
-) -> Union[DerivableMeta, Callable]:
+) -> DerivableMeta | Callable:
     """
     Decorator for creating a new :py:class:`Selector` subclass with additional, optional *bases* and
     attaching the decorated function to it as ``call_func``. All additional *kwargs* are added as
@@ -97,10 +99,10 @@ class SelectionResult(od.AuxDataMixin):
 
     def __init__(
         self,
-        main: Optional[Union[DotDict, dict]] = None,
-        steps: Optional[Union[DotDict, dict]] = None,
-        objects: Optional[Union[DotDict, dict]] = None,
-        aux: Optional[Union[DotDict, dict]] = None,
+        main: DotDict | dict | None = None,
+        steps: DotDict | dict | None = None,
+        objects: DotDict | dict | None = None,
+        aux: DotDict | dict | None = None,
     ):
         super().__init__(aux=aux)
 
@@ -109,7 +111,7 @@ class SelectionResult(od.AuxDataMixin):
         self.steps = DotDict.wrap(steps or {})
         self.objects = DotDict.wrap(objects or {})
 
-    def __iadd__(self, other: Union["SelectionResult", None]) -> "SelectionResult":
+    def __iadd__(self, other: SelectionResult | None) -> SelectionResult:
         """
         Adds the field of an *other* instance in-place. When *None*, *this* instance is returned
         unchanged.
@@ -132,7 +134,7 @@ class SelectionResult(od.AuxDataMixin):
 
         return self
 
-    def __add__(self, other: Union["SelectionResult", None]) -> "SelectionResult":
+    def __add__(self, other: SelectionResult | None) -> SelectionResult:
         """
         Returns a new instance with all fields of *this* and an *other* instance merged. When
         *None*, a copy of *this* instance is returned.

--- a/columnflow/selection/matching.py
+++ b/columnflow/selection/matching.py
@@ -4,7 +4,9 @@
 Distance-based methods.
 """
 
-from typing import Callable, Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Callable
 
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.util import maybe_import
@@ -17,8 +19,8 @@ ak = maybe_import("awkward")
 def cleaning_factory(
     selector_name: str,
     to_clean: str,
-    clean_against: List[str],
-    metric: Optional[Callable] = None,
+    clean_against: list[str],
+    metric: Callable | None = None,
 ) -> Callable:
     """
     factory to generate a function with name *selector_name* that cleans the
@@ -59,10 +61,10 @@ def cleaning_factory(
         self: Selector,
         events: ak.Array,
         to_clean: str,
-        clean_against: List[str],
-        metric: Optional[Callable] = metric,
+        clean_against: list[str],
+        metric: Callable | None = metric,
         threshold: float = 0.4,
-    ) -> List[int]:
+    ) -> list[int]:
         """
         abstract function to perform a cleaning of field *to_clean* against
         a (list of) field(s) *clean_against* based on an abitrary metric
@@ -127,7 +129,7 @@ delta_r_jet_lepton = cleaning_factory(
 def jet_lepton_delta_r_cleaning(
     self: Selector,
     events: ak.Array,
-    stats: Dict[str, Union[int, float]],
+    stats: dict[str, int | float],
     threshold: float = 0.4,
     **kwargs,
 ) -> SelectionResult:

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -175,7 +175,7 @@ class PlotCutflow(
     RemoteWorkflow,
 ):
 
-    sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(CreateCutflowHistograms.shifts)
 
@@ -352,7 +352,7 @@ class PlotCutflowVariables(
         description="when True, only create plots for the final selector step; default: False",
     )
 
-    sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(CreateCutflowHistograms.shifts)
 

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -4,14 +4,15 @@
 Tasks dealing with external data.
 """
 
-__all__ = []
+from __future__ import annotations
 
+__all__ = []
 
 import os
 import time
 import shutil
 import subprocess
-from typing import Union, Tuple, List, Sequence, Optional
+from typing import Sequence
 
 import luigi
 import law
@@ -70,10 +71,10 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
 
     def iter_nano_files(
         self,
-        task: Union[AnalysisTask, DatasetTask],
-        remote_fs: Optional[Union[str, List[str], Tuple[str]]] = None,
-        lfn_indices: Optional[List[int]] = None,
-        eager_lookup: Union[bool, int] = 1,
+        task: AnalysisTask | DatasetTask,
+        remote_fs: str | Sequence[str] | None = None,
+        lfn_indices: list[int] | None = None,
+        eager_lookup: bool | int = 1,
     ) -> None:
         """
         Generator function that reduces the boilerplate code for looping over files referred to by
@@ -127,7 +128,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                 input_stat = input_file.exists(stat=True)
                 duration = time.perf_counter() - t1
                 i += 1
-                logger.info(f"file does {'' if input_stat else 'not'} exist at fs {fs}")
+                logger.info(f"file {lfn} does{'' if input_stat else ' not'} exist at fs {fs}")
 
                 # when the stat query took longer than 2 seconds, eagerly try the next fs
                 # and check if it responds faster and if so, take it instead
@@ -351,7 +352,7 @@ class CreatePileupWeights(ConfigTask):
     def read_mc_profile_from_cfg(
         cls,
         pu_config_target: law.FileSystemTarget,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         Takes a mc pileup configuration file stored in *pu_config_target*, parses its content and
         return the pu profile as a list of float probabilities.
@@ -385,7 +386,7 @@ class CreatePileupWeights(ConfigTask):
     def read_data_profile_from_hist(
         cls,
         pu_hist_target: law.FileSystemTarget,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         Takes the pileup profile in data preproducd by the lumi pog and stored in *pu_hist_target*,
         builds the ratio to mc and returns the weights in a list.
@@ -399,7 +400,7 @@ class CreatePileupWeights(ConfigTask):
         cls,
         pu_file_target: law.FileSystemTarget,
         minbias_xs: float,
-    ) -> List[float]:
+    ) -> list[float]:
         """
         Takes the pileup profile in data read stored in *pu_file_target*, which should have been
         produced when processing data, and a *minbias_mexs* value in mb (milli), builds the ratio to
@@ -408,7 +409,7 @@ class CreatePileupWeights(ConfigTask):
         raise NotImplementedError
 
     @classmethod
-    def normalize_values(cls, values: Sequence[float]) -> List[float]:
+    def normalize_values(cls, values: Sequence[float]) -> list[float]:
         _sum = sum(values, 0.0)
         return [value / _sum for value in values]
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -4,13 +4,15 @@
 Generic tools and base tasks that are defined along typical objects in an analysis.
 """
 
+from __future__ import annotations
+
 import os
 import enum
 import importlib
 import itertools
 import inspect
 import functools
-from typing import Optional, Sequence, List, Union, Set, Dict
+from typing import Sequence
 
 import luigi
 import law
@@ -161,13 +163,13 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     @classmethod
     def find_config_objects(
         cls,
-        names: Union[str, Sequence[str], Set[str]],
+        names: str | Sequence[str] | set[str],
         container: od.UniqueObject,
         object_cls: od.UniqueObjectMeta,
-        object_groups: Optional[Dict[str, list]] = None,
+        object_groups: dict[str, list] | None = None,
         accept_patterns: bool = True,
         deep: bool = False,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Returns all names of objects of type *object_cls* known to a *container* (e.g.
         :py:class:`od.Analysis` or :py:class:`od.Config`) that match *names*. A name can also be a
@@ -765,8 +767,8 @@ def wrapper_factory(
     base_cls: law.Task,
     require_cls: AnalysisTask,
     enable: Sequence[str],
-    cls_name: Optional[str] = None,
-    attributes: Optional[dict] = None,
+    cls_name: str | None = None,
+    attributes: dict | None = None,
 ) -> law.task.base.Register:
     """
     Factory function creating wrapper task classes, inheriting from *base_cls* and

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -4,8 +4,10 @@
 Lightweight mixins task classes.
 """
 
+from __future__ import annotations
+
 import time
-from typing import Union, Sequence, List, Set, Dict, Any
+from typing import Sequence, Any
 
 import law
 import luigi
@@ -231,7 +233,7 @@ class SelectorStepsMixin(SelectorMixin):
     selector_steps_order_sensitive = False
 
     @classmethod
-    def modify_param_values(cls, params: Dict[str, Any]) -> Dict[str, Any]:
+    def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().modify_param_values(params)
 
         # expand selector step groups
@@ -400,7 +402,7 @@ class MLModelMixin(ConfigTask):
     )
 
     @classmethod
-    def modify_param_values(cls, params: Dict[str, Any]) -> Dict[str, Any]:
+    def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().modify_param_values(params)
 
         # add the default ml model when empty
@@ -452,7 +454,7 @@ class MLModelsMixin(ConfigTask):
     )
 
     @classmethod
-    def modify_param_values(cls, params: Dict[str, Any]) -> Dict[str, Any]:
+    def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().modify_param_values(params)
 
         if "config_inst" in params:
@@ -493,7 +495,7 @@ class InferenceModelMixin(ConfigTask):
     )
 
     @classmethod
-    def modify_param_values(cls, params: Dict[str, Any]) -> Dict[str, Any]:
+    def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().modify_param_values(params)
 
         # add the default inference model when empty
@@ -752,11 +754,11 @@ class ShiftSourcesMixin(ConfigTask):
         return params
 
     @classmethod
-    def expand_shift_sources(cls, sources: Union[Sequence[str], Set[str]]) -> List[str]:
+    def expand_shift_sources(cls, sources: Sequence[str] | set[str]) -> list[str]:
         return sum(([f"{s}_up", f"{s}_down"] for s in sources), [])
 
     @classmethod
-    def reduce_shifts(cls, shifts: Union[Sequence[str], Set[str]]) -> List[str]:
+    def reduce_shifts(cls, shifts: Sequence[str] | set[str]) -> list[str]:
         return list(set(od.Shift.split_name(shift)[0] for shift in shifts))
 
     def __init__(self, *args, **kwargs):

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -5,7 +5,7 @@ Base classes for different types of plotting tasks.
 """
 
 import importlib
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 import law
 import luigi
@@ -56,7 +56,7 @@ class PlotBase(AnalysisTask):
 
         return params
 
-    def get_plot_names(self, name: str) -> List[str]:
+    def get_plot_names(self, name: str) -> list[str]:
         """
         Returns a list of basenames for created plots given a file *name* for all configured file
         types, plus the additional plot suffix.

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -17,7 +17,7 @@ from columnflow.tasks.framework.mixins import (
 from columnflow.tasks.framework.plotting import PlotBase, ProcessPlotBase
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from columnflow.util import DotDict
+from columnflow.util import DotDict, dev_sandbox
 
 
 class PlotVariables(
@@ -32,7 +32,7 @@ class PlotVariables(
     RemoteWorkflow,
 ):
 
-    sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     shifts = set(MergeHistograms.shifts)
 
@@ -173,7 +173,7 @@ class PlotShiftedVariables(
     RemoteWorkflow,
 ):
 
-    sandbox = "bash::$CF_BASE/sandboxes/cmssw_default.sh"
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     # default upstream dependency task classes
     dep_MergeShiftedHistograms = MergeShiftedHistograms

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,9 @@
-# version 4
+# version 5
 # packages might be installed in addition to other requirements
 
-ipython==7.16.*
-pytest==7.0.*
+ipython==8.5.*
+pytest==7.1.*
 pytest-cov==3.0.*
-flake8==4.0.*
+flake8==5.0.*
 flake8-commas==2.1.*
 flake8-quotes==3.3.*

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -124,14 +124,14 @@ setup_cmssw() {
             fi
             # start the sleep loop
             while [ -f "${pending_flag_file}" ]; do
-                # wait at most 10 minutes
+                # wait at most 20 minutes
                 sleep_counter="$(( $sleep_counter + 1 ))"
                 if [ "${sleep_counter}" -ge 120 ]; then
                     >&2 echo "cmssw ${CF_CMSSW_VERSION} is setup in different process, but number of sleeps exceeded"
                     return "7"
                 fi
-                echo -e "\x1b[0;49;36mcmssw ${CF_CMSSW_VERSION} already being setup in different process, sleep ${sleep_counter} / 120\x1b[0m"
-                sleep 5
+                cf_color yellow "cmssw ${CF_CMSSW_VERSION} already being setup in different process, sleep ${sleep_counter} / 120"
+                sleep 10
             done
         fi
 

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -144,14 +144,14 @@ setup_venv() {
             fi
             # start the sleep loop
             while [ -f "${pending_flag_file}" ]; do
-                # wait at most 15 minutes
+                # wait at most 20 minutes
                 sleep_counter="$(( $sleep_counter + 1 ))"
-                if [ "${sleep_counter}" -ge 180 ]; then
+                if [ "${sleep_counter}" -ge 120 ]; then
                     >&2 echo "venv ${CF_VENV_NAME} is setup in different process, but number of sleeps exceeded"
                     return "10"
                 fi
-                echo -e "\x1b[0;49;36mvenv ${CF_VENV_NAME} already being setup in different process, sleep ${sleep_counter} / 180\x1b[0m"
-                sleep 5
+                cf_color yellow "venv ${CF_VENV_NAME} already being setup in different process, sleep ${sleep_counter} / 120"
+                sleep 10
             done
         fi
 

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,7 +1,6 @@
-# version 4
+# version 5
 
-pyarrow==6.0.*
 coffea==0.7.*
-awkward==1.9.*
+awkward==1.10.*
 uproot==4.3.*
 tabulate==0.8.*

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,5 +1,4 @@
-# version 2
+# version 3
 
-tensorflow==2.6.*
-pyarrow==6.0.*
-awkward==1.9.*
+tensorflow==2.10.*
+awkward==1.10.*

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ keywords = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -59,7 +58,7 @@ setup(
     classifiers=classifiers,
     long_description=long_description,
     install_requires=install_requires,
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
 )

--- a/setup.sh
+++ b/setup.sh
@@ -535,7 +535,7 @@ cf_color() {
     local msg="${@:2}"
 
     # disable coloring in remote jobs
-    [ "${CF_REMOTE_JOB}" = "1" ] && color="none"
+    ( [ "${CF_REMOTE_JOB}" = "1" ] || [ "${CF_CI_JOB}" = "1" ] ) && color="none"
 
     case "${color}" in
         red)

--- a/setup.sh
+++ b/setup.sh
@@ -290,7 +290,7 @@ cf_setup_interactive() {
             # set the variable when existing
             eval "value=\${$varname:-\$value}"
         else
-            printf "${text} ($( cf_color bright_white ${varname} ), default $( cf_color bright_white ${default_text} )):  "
+            printf "${text} ($( cf_color default_bright ${varname} ), default $( cf_color default_bright ${default_text} )):  "
             read query_response
             [ "X${query_response}" = "X" ] && query_response="${default}"
 
@@ -298,7 +298,7 @@ cf_setup_interactive() {
             while true; do
                 ( [ "${default}" != "True" ] && [ "${default}" != "False" ] ) && break
                 ( [ "${query_response}" = "True" ] || [ "${query_response}" = "False" ] ) && break
-                printf "please enter either '$( cf_color bright_white True )' or '$( cf_color bright_white False )':  " query_response
+                printf "please enter either '$( cf_color default_bright True )' or '$( cf_color default_bright False )':  " query_response
                 read query_response
                 [ "X${query_response}" = "X" ] && query_response="${default}"
             done
@@ -427,6 +427,7 @@ cf_setup_software_stack() {
                     bash setup_miniconda.sh -b -u -p "${CF_CONDA_BASE}" &&
                     rm setup_miniconda.sh &&
                     echo "changeps1: false" >> "${CF_CONDA_BASE}/.condarc"
+                    echo "channel_priority: strict" >> "${CF_CONDA_BASE}/.condarc"
                 ) || return "$?"
             fi
 
@@ -446,8 +447,9 @@ cf_setup_software_stack() {
             # install packages
             if ${conda_missing}; then
                 echo
-                cf_color magenta "setting up conda environment"
-                conda install --yes --channel conda-forge gfal2 gfal2-util python-gfal2 conda-pack || return "$?"
+                cf_color cyan "setting up conda environment"
+                conda config --add channels conda-forge || return "$?"
+                conda install --yes libgcc gfal2 gfal2-util python-gfal2 conda-pack || return "$?"
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack
                 cat << EOF > "${CF_CONDA_BASE}/etc/conda/activate.d/gfal_activate.sh"
@@ -538,6 +540,9 @@ cf_color() {
     ( [ "${CF_REMOTE_JOB}" = "1" ] || [ "${CF_CI_JOB}" = "1" ] ) && color="none"
 
     case "${color}" in
+        default)
+            echo -e "\x1b[0;49;39m${msg}\x1b[0m"
+            ;;
         red)
             echo -e "\x1b[0;49;31m${msg}\x1b[0m"
             ;;
@@ -556,26 +561,26 @@ cf_color() {
         cyan)
             echo -e "\x1b[0;49;36m${msg}\x1b[0m"
             ;;
-        bright_white)
-            echo -e "\x1b[0;49;39m${msg}\x1b[0m"
+        default_bright)
+            echo -e "\x1b[1;49;39m${msg}\x1b[0m"
             ;;
-        bright_red)
-            echo -e "\x1b[0;49;91m${msg}\x1b[0m"
+        red_bright)
+            echo -e "\x1b[1;49;31m${msg}\x1b[0m"
             ;;
-        bright_green)
-            echo -e "\x1b[0;49;92m${msg}\x1b[0m"
+        green_bright)
+            echo -e "\x1b[1;49;32m${msg}\x1b[0m"
             ;;
-        bright_yellow)
-            echo -e "\x1b[0;49;93m${msg}\x1b[0m"
+        yellow_bright)
+            echo -e "\x1b[1;49;33m${msg}\x1b[0m"
             ;;
-        bright_blue)
-            echo -e "\x1b[0;49;94m${msg}\x1b[0m"
+        blue_bright)
+            echo -e "\x1b[1;49;34m${msg}\x1b[0m"
             ;;
-        bright_magenta)
-            echo -e "\x1b[0;49;95m${msg}\x1b[0m"
+        magenta_bright)
+            echo -e "\x1b[1;49;35m${msg}\x1b[0m"
             ;;
-        bright_cyan)
-            echo -e "\x1b[0;49;96m${msg}\x1b[0m"
+        cyan_bright)
+            echo -e "\x1b[1;49;36m${msg}\x1b[0m"
             ;;
         *)
             echo "${msg}"

--- a/setup.sh
+++ b/setup.sh
@@ -426,9 +426,14 @@ cf_setup_software_stack() {
                     wget "${miniconda_source}" -O setup_miniconda.sh &&
                     bash setup_miniconda.sh -b -u -p "${CF_CONDA_BASE}" &&
                     rm setup_miniconda.sh &&
-                    echo "changeps1: false" >> "${CF_CONDA_BASE}/.condarc"
-                    echo "channel_priority: strict" >> "${CF_CONDA_BASE}/.condarc"
-                ) || return "$?"
+                    cat << EOF >> "${CF_CONDA_BASE}/.condarc"
+changeps1: false
+channel_priority: strict
+channels:
+  - conda-forge
+  - defaults
+EOF
+                )
             fi
 
             # initialize conda
@@ -448,7 +453,6 @@ cf_setup_software_stack() {
             if ${conda_missing}; then
                 echo
                 cf_color cyan "setting up conda environment"
-                conda config --add channels conda-forge || return "$?"
                 conda install --yes libgcc gfal2 gfal2-util python-gfal2 conda-pack || return "$?"
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack

--- a/setup.sh
+++ b/setup.sh
@@ -397,6 +397,7 @@ cf_setup_software_stack() {
     export X509_CERT_DIR="${X509_CERT_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/certificates}"
     export X509_VOMS_DIR="${X509_VOMS_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/vomsdir}"
     export X509_VOMSES="${X509_VOMSES:-/cvmfs/grid.cern.ch/etc/grid-security/vomses}"
+    export VOMS_USERCONF="${VOMS_USERCONF:-${X509_VOMSES}}"
     ulimit -s unlimited
 
     # local python stack in one conda env and two virtual envs:
@@ -428,7 +429,6 @@ cf_setup_software_stack() {
                     rm setup_miniconda.sh &&
                     cat << EOF >> "${CF_CONDA_BASE}/.condarc"
 changeps1: false
-channel_priority: strict
 channels:
   - conda-forge
   - defaults
@@ -462,6 +462,7 @@ export GFAL_PLUGIN_DIR="\${CONDA_PREFIX}/lib/gfal2-plugins"
 export X509_CERT_DIR="${X509_CERT_DIR}"
 export X509_VOMS_DIR="${X509_VOMS_DIR}"
 export X509_VOMSES="${X509_VOMSES}"
+export VOMS_USERCONF="${VOMS_USERCONF}"
 EOF
             fi
         fi


### PR DESCRIPTION
With the new conda-based setup in #107, we can update large parts of our code base to use some newer python features as well as update some of the requirements in the base venvs.

This PR adds exactly these changes but should only be merged when #107 is included.
Until then, there are some minor TODOs left:

- [x] Change sandboxes of plotting tasks to the default columnar env.
- [x] Merge master back in.