### PR TITLE
Add priority-based task queue to ChunkedReader.

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -108,7 +108,7 @@ class CalibrateEvents(
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{lfn_index}_{pos.index}.parquet", type="f")
             output_chunks[(lfn_index, pos.index)] = chunk
-            self.chunked_reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge output files
         with output.localize("w") as outp:

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -141,7 +141,7 @@ class PrepareMLEvents(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{f}_{pos.index}.parquet", type="f")
                 output_chunks[f][pos.index] = chunk
-                self.chunked_reader.add_task(sorted_ak_to_parquet, (fold_events, chunk.path))
+                self.chunked_reader.queue(sorted_ak_to_parquet, (fold_events, chunk.path))
 
         # merge output files of all folds
         for _output_chunks, output in zip(output_chunks, outputs.targets):
@@ -423,7 +423,7 @@ class MLEvaluation(
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
             output_chunks[pos.index] = chunk
-            self.chunked_reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -100,7 +100,7 @@ class ProduceColumns(
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
             output_chunks[pos.index] = chunk
-            self.chunked_reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -167,7 +167,7 @@ class ReduceEvents(
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
             output_chunks[pos.index] = chunk
-            self.chunked_reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # some logs
         self.publish_message(

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -145,7 +145,7 @@ class SelectEvents(
             # save results as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")
             result_chunks[(lfn_index, pos.index)] = chunk
-            self.chunked_reader.add_task(sorted_ak_to_parquet, (results.to_ak(), chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (results.to_ak(), chunk.path))
 
             # remove columns
             if keep_columns:
@@ -154,7 +154,7 @@ class SelectEvents(
                 # save additional columns as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"cols_{lfn_index}_{pos.index}.parquet", type="f")
                 column_chunks[(lfn_index, pos.index)] = chunk
-                self.chunked_reader.add_task(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_reader.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge the result files
         sorted_chunks = [result_chunks[key] for key in sorted(result_chunks)]


### PR DESCRIPTION
This PR updates the `ChunkedReader` in `columnar_util.py` and adds:

- A debug flag that can be set to *True* from the command line using an env variable `CF_CHUNKED_READER_DEBUG=1` that sets the queue size for reading to 1 and uses a fake thread pool for processing in the main thread which allows easier debugging.
- A task queue that is based on priorities. The ChunkedReader not only reads chunks of input files in multiple threads, but also allows adding new so-called tasks to the queue to process. So far, this was utilized to take advantage of the same thread pool to write back files to parquet. However, in order to free memory of columns to write, these steps should actually be priotized over reading in new chunks. This is now implemented.
- Since there were some issues with deserialized chunks being held in memory by either awkward or coffea, all methods in the ChunkedReader that interact with IO now disable all possible caches. This might not be the smartest thing to do in all situations, but for now it fixes the issue we saw (and we anyway have to rethink our IO when ak v2 hits).