### PR TITLE
Enable local processing

### DIFF
--- a/law.cfg
+++ b/law.cfg
@@ -33,7 +33,7 @@ wlcg_file_systems: wlcg_fs, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 
 # list of file systems used by columnflow.tasks.external.GetDatasetLFNs.iter_nano_files to
 # look for the correct fs per nano input file (in that order)
-wlcg_lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
+lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 
 # output locations per task family
 # for local targets : "local[, STORE_PATH]"


### PR DESCRIPTION
As discussed earlier, we need a way for collaborators / students without grid certificates to work with analyses derived from the default columnflow workflow that starts with `GetDatasetLFNs` and tasks that use the lfns subsequently.

This PR adds the means to do so by only adding a minor change to the way that external LFNs are handled by the `GetDatasetLFNs` task. With that, I would propose the following way to work fully locally:

- The initial LFNs need to be run once **with** a certificate (there is no other way to obtain them), but they should be stored locally in a shared directory.
- The method `GetDatasetLFNs.iter_nano_files` uses a list of file system names to look for specific lfns. So far, these fs's had to be wlcg file systems, but from now on, they can also be local ones. An example at desy would be:

```
[local_desy_dcache]
base: /pnfs/desy.de/cms/tier2
````

- With that, if a local target is created as e.g. `law.LocalFileTarget("/store/...", fs="local_desy_dcache)`, the path is properly resolved to the local dcache mount.
- To tell `GetDatasetLFNs.iter_nano_files` to use only that fs, one can configure the lfn sources via:

```
[outputs]
lfn_sources: local_desy_dcache
```

- Needless to say, the output locations of all other tasks should be adjusted to the local fs.
- Students can create a custom law config file that inherits from the analysis' main `law.cfg`, and only overwrites the options above.