### PR TITLE
Feature/plot2dplotter

### DIFF
--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -464,4 +464,7 @@ def plot_cutflow(
     }
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
 
+    # ratio plot not used here; set `skip_ratio` to True
+    kwargs["skip_ratio"] = True
+
     return plot_all(plot_config, style_config, **kwargs)

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -7,11 +7,12 @@ Example plot functions.
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Sequence
+from typing import Sequence, Iterable
 
 import law
 
 from columnflow.util import maybe_import, test_float
+from columnflow.plotting.plot_util import prepare_plot_config
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -231,89 +232,8 @@ def plot_variable_per_process(
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
 
-    # process_settings
-    if not process_settings:
-        process_settings = {}
-
-    # separate histograms into stack, lines and data hists
-    data_hists, mc_hists, mc_colors, mc_labels = [], [], [], []
-    line_hists, line_colors, line_labels = [], [], []
-
-    for process_inst, h in hists.items():
-        # get settings for this process
-        settings = process_settings.get(process_inst.name, {})
-        color1 = settings.get("color1", settings.get("color", process_inst.color1))
-        color2 = settings.get("color2", process_inst.color2)
-        label = settings.get("label", process_inst.label)
-
-        if "scale" in settings.keys():
-            h = h * settings["scale"]
-            label = f"{label} x{settings['scale']}"
-
-        if process_inst.is_data:
-            data_hists.append(h)
-        elif process_inst.is_mc:
-            if "unstack" in settings:
-                line_hists.append(h)
-                line_colors.append(color1)
-                line_labels.append(label)
-            else:
-                mc_hists.append(h)
-                mc_colors.append(color1)
-                line_colors.append(color2)
-                mc_labels.append(label)
-
-    h_data, h_mc, h_mc_stack = None, None, None
-    if data_hists:
-        h_data = sum(data_hists[1:], data_hists[0].copy())
-    if mc_hists:
-        h_mc = sum(mc_hists[1:], mc_hists[0].copy())
-        h_mc_stack = hist.Stack(*mc_hists)
-
-    # setup plotting configs
-    plot_config = {}
-
-    # draw stack + error bands
-    if h_mc_stack:
-        mc_norm = sum(h_mc.values()) if shape_norm else 1
-        plot_config["mc_stack"] = {
-            "method": "draw_stack",
-            "hist": h_mc_stack,
-            "kwargs": {
-                "norm": mc_norm,
-                "label": mc_labels,
-                "color": mc_colors,
-                "edgecolor": line_colors,
-                "linewidth": [(0 if c is None else 1) for c in line_colors],
-            },
-        }
-        plot_config["mc_uncert"] = {
-            "method": "draw_error_bands",
-            "hist": h_mc,
-            "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
-            "ratio_kwargs": {"norm": h_mc.values()},
-        }
-
-    # draw lines
-    for i, h in enumerate(line_hists):
-        label = line_labels[i]
-        line_norm = sum(h.values()) if shape_norm else 1
-        plot_config[f"line_{label}"] = {
-            "method": "draw_hist",
-            "hist": h,
-            "kwargs": {"norm": line_norm, "label": label, "color": line_colors[i]},
-            # "ratio_kwargs": {"norm": h.values(), "color": line_colors[i]},
-        }
-
-    # draw data
-    if data_hists:
-        data_norm = sum(h_data.values()) if shape_norm else 1
-        plot_config["data"] = {
-            "method": "draw_errorbars",
-            "hist": h_data,
-            "kwargs": {"norm": data_norm, "label": "Data"},
-            "ratio_kwargs": {"norm": h_mc.values()},
-        }
+    # setup plotting config
+    plot_config = prepare_plot_config(hists, shape_norm, process_settings)
 
     # setup style config
     if not yscale:
@@ -502,63 +422,31 @@ def plot_cutflow(
     if not process_settings:
         process_settings = {}
 
-    mc_hists, mc_colors, mc_line_colors, mc_labels, data_hists = [], [], [], [], []
-    for process_inst, h in hists.items():
-        # get settings for this process
-        settings = process_settings.get(process_inst.name, {})
-        color1 = settings.get("color1", settings.get("color", process_inst.color1))
-        color2 = settings.get("color2", process_inst.color2)
-        label = settings.get("label", process_inst.label)
+    # setup plotting config
+    plot_config = prepare_plot_config(hists, shape_norm, process_settings)
 
-        if process_inst.is_mc:
-            mc_hists.append(h)
-            mc_colors.append(color1)
-            mc_line_colors.append(color2)
-            mc_labels.append(label)
-        else:
-            data_hists.append(h)
-
-    # create the stack
-    h_mc_stack, h_data = None, None
-    if mc_hists:
-        h_mc_stack = hist.Stack(*mc_hists)
-    if data_hists:
-        h_data = sum(data_hists[1:], data_hists[0].copy())
-
-    # setup plotting configs
-    if not yscale:
-        yscale = "linear"
-
-    plot_config = {
-        "procs": {
-            "method": "draw_stack",
-            "hist": h_mc_stack,
-            "kwargs": {
-                "norm": [h[{"step": "Initial"}].value for h in mc_hists] if shape_norm else 1,
-                "label": mc_labels,
-                "color": mc_colors,
-                "edgecolor": mc_line_colors,
-                "linewidth": [(0 if c is None else 1) for c in mc_line_colors],
-                "histtype": "step",
-                "stack": False,
-            },
-        },
-    }
-    if data_hists:
-        plot_config["data"] = {
-            "method": "draw_hist",
-            "hist": h_data,
-            "kwargs": {
-                "norm": h_data[{"step": "Initial"}].value if shape_norm else 1,
-                "label": "Data",
-            },
-        }
+    if shape_norm:
+        # switch normalization to normalizing to `initial step` bin
+        for key in list(plot_config):
+            item = plot_config[key]
+            h_key = item["hist"]
+            if isinstance(h_key, Iterable):
+                norm = sum(h[{"step": "Initial"}].value for h in h_key)
+            else:
+                norm = h_key[{"step": "Initial"}].value
+            item["kwargs"]["norm"] = norm
 
     # update xticklabels based on config
     xticklabels = []
     selector_step_labels = config_inst.x("selector_step_labels", {})
-    for xtl in list(mc_hists[0].axes["step"]):
-        xticklabels.append(selector_step_labels.get(xtl, xtl))
+
+    selector_steps = list(hists[list(hists.keys())[0]].axes["step"])
+    for step in selector_steps:
+        xticklabels.append(selector_step_labels.get(step, step))
+
+    # setup style config
+    if not yscale:
+        yscale = "linear"
 
     default_style_config = {
         "ax_cfg": {

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -222,13 +222,14 @@ def plot_all(
 def plot_variable_per_process(
     hists: OrderedDict,
     config_inst: od.config,
-    variable_inst: od.variable,
+    variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool | None = False,
     yscale: str | None = "",
     process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
+    variable_inst = variable_insts[0]
 
     # process_settings
     if not process_settings:
@@ -344,12 +345,14 @@ def plot_variable_per_process(
 def plot_variable_variants(
     hists: OrderedDict,
     config_inst: od.config,
-    variable_inst: od.variable,
+    variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
     **kwargs,
 ) -> plt.Figure:
+    variable_inst = variable_insts[0]
+
     plot_config = OrderedDict()
 
     # for updating labels of individual selector steps
@@ -366,6 +369,7 @@ def plot_variable_variants(
         }
 
     # setup style config
+
     if not yscale:
         yscale = "log" if variable_inst.log_y else "linear"
 
@@ -397,7 +401,7 @@ def plot_variable_variants(
 def plot_shifted_variable(
     hists: Sequence[hist.Hist],
     config_inst: od.config,
-    variable_inst: od.variable,
+    variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
@@ -405,6 +409,8 @@ def plot_shifted_variable(
     process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
+    variable_inst = variable_insts[0]
+
     # create the sum of histograms over all processes
     h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
 

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+
+"""
+Example 2d plot functions.
+"""
+
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import law
+
+from columnflow.util import maybe_import
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+mpl = maybe_import("matplotlib")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+od = maybe_import("order")
+
+
+def plot_2d(
+    hists: OrderedDict,
+    config_inst: od.config,
+    variable_insts: list[od.variable],
+    style_config: dict | None = None,
+    shape_norm: bool | None = False,  # TODO use
+    zscale: str | None = "",
+    skip_legend: bool = False,
+    skip_cms: bool = False,
+    process_settings: dict | None = None,  # TODO use
+    **kwargs,
+) -> plt.Figure:
+
+    # use CMS plotting style
+    plt.style.use(mplhep.style.CMS)
+    fig, ax = plt.subplots()
+
+    # how to handle yscale information from 2 variable insts?
+    if not zscale:
+        zscale = "log" if (variable_insts[0].log_y or variable_insts[1].log_y) else "linear"
+
+    # setup style config
+    default_style_config = {
+        "ax_cfg": {
+            "xlim": (variable_insts[0].x_min, variable_insts[0].x_max),
+            "ylim": (variable_insts[1].x_min, variable_insts[1].x_max),
+            "xlabel": variable_insts[0].get_full_x_title(),
+            "ylabel": variable_insts[1].get_full_x_title(),
+            # "zlabel": variable_insts[0].get_full_y_title(),  # ?
+            # "zscale": zscale,
+        },
+        "legend_cfg": {},
+        "cms_label_cfg": {
+            "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
+        },
+    }
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
+    # NOTE: should we separate into multiple functions similar to 1d plotting?
+
+    # add all processes into 1 histogram
+    h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
+
+    # apply style_config
+    ax.set(**style_config["ax_cfg"])
+    ax.legend(**style_config["legend_cfg"])
+
+    # cms label (some TODOs might still be open here)
+    cms_label_kwargs = {
+        "ax": ax,
+        "llabel": "Work in progress",
+        "fontsize": 22,
+    }
+    cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
+    if skip_cms:
+        cms_label_kwargs.update({"data": True, "label": ""})
+    mplhep.cms.label(**cms_label_kwargs)
+
+    plt.tight_layout()
+
+    h_sum.plot2d(ax=ax, norm=mpl.colors.LogNorm())
+
+    return fig

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+
+"""
+Some utils for plot functions.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from columnflow.util import maybe_import
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+od = maybe_import("order")
+
+
+def prepare_plot_config(
+    hists: OrderedDict,
+    shape_norm: bool | None = False,
+    process_settings: dict | None = None,
+) -> OrderedDict:
+    """
+    Prepares a plot config with one entry to create plots containing a stack of
+    backgrounds with uncertainty bands, unstacked processes as lines and
+    data entrys with errorbars.
+    `process-settings` (unstack, scale, color, label) and `shape-norm` are applied.
+    """
+
+    # process_settings
+    if not process_settings:
+        process_settings = {}
+
+    # separate histograms into stack, lines and data hists
+    mc_hists, mc_colors, mc_edgecolors, mc_labels = [], [], [], []
+    line_hists, line_colors, line_labels = [], [], []
+    data_hists = []
+
+    for process_inst, h in hists.items():
+        # get settings for this process
+        settings = process_settings.get(process_inst.name, {})
+        color1 = settings.get("color1", settings.get("color", process_inst.color1))
+        color2 = settings.get("color2", process_inst.color2)
+        label = settings.get("label", process_inst.label)
+
+        if "scale" in settings.keys():
+            h = h * settings["scale"]
+            label = f"{label} x{settings['scale']}"
+
+        if process_inst.is_data:
+            data_hists.append(h)
+        elif process_inst.is_mc:
+            if settings.get("unstack", False):
+                line_hists.append(h)
+                line_colors.append(color1)
+                line_labels.append(label)
+            else:
+                mc_hists.append(h)
+                mc_colors.append(color1)
+                mc_edgecolors.append(color2)
+                mc_labels.append(label)
+
+    h_data, h_mc, h_mc_stack = None, None, None
+    if data_hists:
+        h_data = sum(data_hists[1:], data_hists[0].copy())
+    if mc_hists:
+        h_mc = sum(mc_hists[1:], mc_hists[0].copy())
+        h_mc_stack = hist.Stack(*mc_hists)
+
+    # setup plotting configs
+    plot_config = OrderedDict()
+
+    # draw stack + error bands
+    if h_mc_stack:
+        mc_norm = sum(h_mc.values()) if shape_norm else 1
+        plot_config["mc_stack"] = {
+            "method": "draw_stack",
+            "hist": h_mc_stack,
+            "kwargs": {
+                "norm": mc_norm,
+                "label": mc_labels,
+                "color": mc_colors,
+                "edgecolor": mc_edgecolors,
+                "linewidth": [(0 if c is None else 1) for c in line_colors],
+            },
+        }
+        plot_config["mc_uncert"] = {
+            "method": "draw_error_bands",
+            "hist": h_mc,
+            "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
+            "ratio_kwargs": {"norm": h_mc.values()},
+        }
+    # draw lines
+    for i, h in enumerate(line_hists):
+        label = line_labels[i]
+        line_norm = sum(h.values()) if shape_norm else 1
+        plot_config[f"line_{i}"] = {
+            "method": "draw_hist",
+            "hist": h,
+            "kwargs": {"norm": line_norm, "label": label, "color": line_colors[i]},
+            # "ratio_kwargs": {"norm": h.values(), "color": line_colors[i]},
+        }
+
+    # draw data
+    if data_hists:
+        data_norm = sum(h_data.values()) if shape_norm else 1
+        plot_config["data"] = {
+            "method": "draw_errorbars",
+            "hist": h_data,
+            "kwargs": {"norm": data_norm, "label": "Data"},
+            "ratio_kwargs": {"norm": h_mc.values()},
+        }
+
+    return plot_config

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -12,9 +12,9 @@ import law
 
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, VariablesMixin, ChunkedReaderMixin,
+    CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedReaderMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, ProcessPlotBase
+from columnflow.tasks.framework.plotting import PlotBase, ProcessPlotSettingMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -174,7 +174,8 @@ class PlotCutflow(
     ShiftTask,
     SelectorStepsMixin,
     CalibratorsMixin,
-    ProcessPlotBase,
+    CategoriesMixin,
+    ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -338,7 +339,7 @@ class PlotCutflowVariables(
     VariablesMixin,
     SelectorStepsMixin,
     CalibratorsMixin,
-    ProcessPlotBase,
+    ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -349,6 +349,7 @@ class PlotCutflowVariablesBase(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
+    exclude_index = True
 
     only_final_step = luigi.BoolParameter(
         default=False,
@@ -607,6 +608,8 @@ class PlotCutflowVariables2d(
         outputs = self.output()
 
         for step in self.chosen_steps:
+            # TODO: implement a 'per_process' parameter similar to PlotShiftedVariables
+            #       (maybe as parameter in ProcessPlotSettingMixin, since we could also use this in PlotVariables)
             for process_inst, h in hists.items():
                 h_step = {process_inst: h[{"step": hist.loc(step)}]}
 
@@ -616,6 +619,7 @@ class PlotCutflowVariables2d(
                     hists=h_step,
                     config_inst=self.config_inst,
                     variable_insts=variable_insts,
+                    style_config={"legend_cfg": {"title": f"Step '{step}'"}},
                     **self.get_plot_parameters(),
                 )
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -185,7 +185,7 @@ class PlotCutflow(
 
     shifts = set(CreateCutflowHistograms.shifts)
 
-    plot_function_name_1d = luigi.Parameter(
+    plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_cutflow",
         significant=False,
         description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_cutflow'",
@@ -312,7 +312,7 @@ class PlotCutflow(
 
             # call the plot function
             fig = self.call_plot_func(
-                self.plot_function_name_1d,
+                self.plot_function_1d,
                 hists=hists,
                 config_inst=self.config_inst,
                 **self.get_plot_parameters(),
@@ -498,8 +498,8 @@ class PlotCutflowVariables1d(
         "default: processes",
     )
     # TODO: combine these hard-coded plot function name with law parameter
-    plot_function_name_per_process = "columnflow.plotting.example.plot_variable_per_process"
-    plot_function_name_per_step = "columnflow.plotting.example.plot_variable_variants"
+    plot_function_per_process = "columnflow.plotting.example.plot_variable_per_process"
+    plot_function_per_step = "columnflow.plotting.example.plot_variable_variants"
 
     def output(self):
         b = self.branch_data
@@ -537,7 +537,7 @@ class PlotCutflowVariables1d(
 
                 # call the plot function
                 fig = self.call_plot_func(
-                    self.plot_function_name_per_process,
+                    self.plot_function_per_process,
                     hists=step_hists,
                     config_inst=self.config_inst,
                     variable_insts=variable_insts,
@@ -558,7 +558,7 @@ class PlotCutflowVariables1d(
 
                 # call the plot function
                 fig = self.call_plot_func(
-                    self.plot_function_name_per_step,
+                    self.plot_function_per_step,
                     hists=process_hists,
                     config_inst=self.config_inst,
                     variable_insts=variable_insts,
@@ -606,7 +606,7 @@ class PlotCutflowVariables2d(
 
                 # call the plot function
                 fig = self.call_plot_func(
-                    self.plot_function_name_2d,
+                    self.plot_function_2d,
                     hists=h_step,
                     config_inst=self.config_inst,
                     variable_insts=variable_insts,

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -14,7 +14,7 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedReaderMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, ProcessPlotSettingMixin
+from columnflow.tasks.framework.plotting import PlotBase, PlotBase1d, ProcessPlotSettingMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -175,6 +175,7 @@ class PlotCutflow(
     SelectorStepsMixin,
     CalibratorsMixin,
     CategoriesMixin,
+    PlotBase1d,
     ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
@@ -339,6 +340,7 @@ class PlotCutflowVariables(
     VariablesMixin,
     SelectorStepsMixin,
     CalibratorsMixin,
+    PlotBase1d,
     ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -196,15 +196,6 @@ class PlotCutflow(
     # default upstream dependency task classes
     dep_CreateCutflowHistograms = CreateCutflowHistograms
 
-    def get_plot_parameters(self):
-        params = super().get_plot_parameters()
-
-        # no ratio plot implemented: disable ratio plot for `plot_cutflow`
-        if self.plot_function_name_1d == "columnflow.plotting.example.plot_cutflow":
-            params["skip_ratio"] = True
-
-        return params
-
     def create_branch_map(self):
         # one category per branch
         if not self.categories:

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -211,7 +211,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         object_names = []
         patterns = []
-        lookup = list(names)
+        lookup = law.util.make_list(names)
         while lookup:
             name = lookup.pop(0)
             if has_obj(name):

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -657,18 +657,18 @@ class VariablesMixin(ConfigTask):
     @classmethod
     def split_multi_variable(cls, variable: str) -> tuple[str]:
         """
-        Splits a multi-dimensional *variable* given in the format ``"var_a[_vs_var_b[_vs_]]"`` into
-        separate variable names using a delimiter (``"_vs_"``) and returns a tuple.
+        Splits a multi-dimensional *variable* given in the format ``"var_a[-var_b[-...]]"`` into
+        separate variable names using a delimiter (``"-"``) and returns a tuple.
         """
-        return tuple(variable.split("_vs_"))
+        return tuple(variable.split("-"))
 
     @classmethod
     def join_multi_variable(cls, variables: Sequence[str]) -> str:
         """
-        Joins the name of multiple *variables* using a delimiter (``"_vs_"``) into a single string
+        Joins the name of multiple *variables* using a delimiter (``"-"``) into a single string
         that represents a multi-dimensional variable and returns it.
         """
-        return "_vs_".join(map(str, variables))
+        return "-".join(map(str, variables))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -631,6 +631,15 @@ class VariablesMixin(ConfigTask):
 
         return params
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # if enabled, split names of multi-dimensional parameters into tuples using "*_vs_*"
+        self.variable_tuples = {
+            var_name: tuple(var_name.split("_vs_"))
+            for var_name in self.variables
+        }
+
     @property
     def variables_repr(self):
         if len(self.variables) == 1:

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -7,6 +7,7 @@ Lightweight mixins task classes.
 from __future__ import annotations
 
 import time
+import itertools
 from typing import Sequence, Any
 
 import law
@@ -612,13 +613,35 @@ class VariablesMixin(ConfigTask):
 
             # resolve them
             if params["variables"]:
-                # resolve variable names
+                # first, split into single- and multi-dimensional variables
+                single_vars = []
+                multi_var_parts = []
+                for variable in params["variables"]:
+                    parts = cls.split_multi_variable(variable)
+                    if len(parts) == 1:
+                        single_vars.append(variable)
+                    else:
+                        multi_var_parts.append(parts)
+
+                # resolve single variables
                 variables = cls.find_config_objects(
-                    params["variables"],
+                    single_vars,
                     config_inst,
                     od.Variable,
                     config_inst.x("variable_groups", {}),
                 )
+
+                # for each multi-variable, resolve each part separately and create the full
+                # combinatorics of all possibly pattern-resolved parts
+                for parts in multi_var_parts:
+                    resolved_parts = [
+                        cls.find_config_objects(part, config_inst, od.Variable)
+                        for part in parts
+                    ]
+                    variables.extend([
+                        cls.join_multi_variable(_parts)
+                        for _parts in itertools.product(*resolved_parts)
+                    ])
             else:
                 # fallback to using all known variables
                 variables = config_inst.variables.names()

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -631,12 +631,28 @@ class VariablesMixin(ConfigTask):
 
         return params
 
+    @classmethod
+    def split_multi_variable(cls, variable: str) -> tuple[str]:
+        """
+        Splits a multi-dimensional *variable* given in the format ``"var_a[_vs_var_b[_vs_]]"`` into
+        separate variable names using a delimiter (``"_vs_"``) and returns a tuple.
+        """
+        return tuple(variable.split("_vs_"))
+
+    @classmethod
+    def join_multi_variable(cls, variables: Sequence[str]) -> str:
+        """
+        Joins the name of multiple *variables* using a delimiter (``"_vs_"``) into a single string
+        that represents a multi-dimensional variable and returns it.
+        """
+        return "_vs_".join(map(str, variables))
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # if enabled, split names of multi-dimensional parameters into tuples using "*_vs_*"
+        # if enabled, split names of multi-dimensional parameters into tuples
         self.variable_tuples = {
-            var_name: tuple(var_name.split("_vs_"))
+            var_name: self.split_multi_variable(var_name)
             for var_name in self.variables
         }
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -12,7 +12,7 @@ import luigi
 
 from columnflow.tasks.framework.base import AnalysisTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
-from columnflow.util import test_float, DotDict
+from columnflow.util import test_float, DotDict, dict_add_strict
 
 
 class PlotBase(AnalysisTask):
@@ -50,10 +50,8 @@ class PlotBase(AnalysisTask):
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = DotDict({})
-
-        params["skip_legend"] = self.skip_legend
-        params["skip_cms"] = self.skip_cms
-
+        dict_add_strict(params, "skip_legend", self.skip_legend)
+        dict_add_strict(params, "skip_cms", self.skip_cms)
         return params
 
     def get_plot_names(self, name: str) -> list[str]:
@@ -186,13 +184,9 @@ class PlotBase1d(PlotBase):
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
-
-        params_to_add = {
-            "skip_ratio": self.skip_ratio,
-            "yscale": None if self.yscale == law.NO_STR else self.yscale,
-            "shape_norm": self.shape_norm,
-        }
-        params.cautious_update(params_to_add)
+        dict_add_strict(params, "skip_ratio", self.skip_ratio)
+        dict_add_strict(params, "yscale", None if self.yscale == law.NO_STR else self.yscale)
+        dict_add_strict(params, "shape_norm", self.shape_norm)
         return params
 
 
@@ -233,7 +227,7 @@ class ProcessPlotSettingMixin(
             proc_settings[0]: dict(map(parse_setting, proc_settings[1:]))
             for proc_settings in self.process_settings
         }
-        params.cautious_update({"process_settings": process_settings})
+        dict_add_strict(params, "process_settings", process_settings)
 
         return params
 
@@ -292,11 +286,6 @@ class PlotBase2d(PlotBase):
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
-
-        params_to_add = {
-            "zscale": None if self.zscale == law.NO_STR else self.zscale,
-            "shape_norm": self.shape_norm,
-        }
-        params.cautious_update(params_to_add)
-
+        dict_add_strict(params, "zscale", None if self.zscale == law.NO_STR else self.zscale)
+        dict_add_strict(params, "shape_norm", self.shape_norm)
         return params

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -287,6 +287,12 @@ class PlotBase2d(PlotBase):
         description="string parameter to define the z-axis scale of the plot; "
         "choices: NO_STR,linear,log; no default",
     )
+    shape_norm = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, the overall bin content is normalized on its integral; "
+        "default: False",
+    )
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
@@ -294,6 +300,7 @@ class PlotBase2d(PlotBase):
 
         params_to_add = {
             "zscale": None if self.zscale == law.NO_STR else self.zscale,
+            "shape_norm": self.shape_norm,
         }
         params.cautious_update(params_to_add)
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -156,7 +156,7 @@ class PlotBase1d(PlotBase):
     Base class for plotting tasks creating 1-dimensional plots.
     """
 
-    plot_function_name_1d = luigi.Parameter(
+    plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_variable_per_process",
         significant=False,
         description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
@@ -264,7 +264,7 @@ class PlotBase2d(PlotBase):
     Base class for plotting tasks creating 2-dimensional plots.
     """
 
-    plot_function_name_2d = luigi.Parameter(
+    plot_function_2d = luigi.Parameter(
         default="columnflow.plotting.plot2d.plot_2d",
         significant=False,
         description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -20,11 +20,6 @@ class PlotBase(AnalysisTask):
     Base class for all plotting tasks.
     """
 
-    plot_function_name = luigi.Parameter(
-        default="",
-        significant=False,
-        description="name of the plot function; empty default",
-    )
     file_types = law.CSVParameter(
         default=("pdf",),
         significant=True,

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -12,7 +12,7 @@ import luigi
 
 from columnflow.tasks.framework.base import AnalysisTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
-from columnflow.util import test_float
+from columnflow.util import test_float, DotDict
 
 
 class PlotBase(AnalysisTask):
@@ -52,9 +52,9 @@ class PlotBase(AnalysisTask):
         description="when True, no CMS logo is drawn; default: False",
     )
 
-    def get_plot_parameters(self):
+    def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
-        params = {}
+        params = DotDict({})
 
         params["skip_legend"] = self.skip_legend
         params["skip_cms"] = self.skip_cms
@@ -188,14 +188,16 @@ class PlotBase1d(PlotBase):
         "default: False",
     )
 
-    def get_plot_parameters(self):
+    def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
 
-        params["skip_ratio"] = self.skip_ratio
-        params["yscale"] = None if self.yscale == law.NO_STR else self.yscale
-        params["shape_norm"] = self.shape_norm
-
+        params_to_add = {
+            "skip_ratio": self.skip_ratio,
+            "yscale": None if self.yscale == law.NO_STR else self.yscale,
+            "shape_norm": self.shape_norm,
+        }
+        params.cautious_update(params_to_add)
         return params
 
 
@@ -217,7 +219,7 @@ class ProcessPlotSettingMixin(
         brace_expand=True,
     )
 
-    def get_plot_parameters(self):
+    def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
 
@@ -232,10 +234,12 @@ class ProcessPlotSettingMixin(
                 value = False
             return (key, value)
 
-        params["process_settings"] = {
+        process_settings = {
             proc_settings[0]: dict(map(parse_setting, proc_settings[1:]))
             for proc_settings in self.process_settings
         }
+        params.cautious_update({"process_settings": process_settings})
+
         return params
 
     @classmethod
@@ -284,10 +288,13 @@ class PlotBase2d(PlotBase):
         "choices: NO_STR,linear,log; no default",
     )
 
-    def get_plot_parameters(self):
+    def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
 
-        params["zscale"] = None if self.zscale == law.NO_STR else self.zscale
+        params_to_add = {
+            "zscale": None if self.zscale == law.NO_STR else self.zscale,
+        }
+        params.cautious_update(params_to_add)
 
         return params

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -163,6 +163,11 @@ class PlotBase1d(PlotBase):
     Base class for plotting tasks creating 1-dimensional plots.
     """
 
+    plot_function_name_1d = luigi.Parameter(
+        default="columnflow.plotting.example.plot_variable_per_process",
+        significant=False,
+        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
+    )
     skip_ratio = luigi.BoolParameter(
         default=False,
         significant=False,
@@ -266,6 +271,11 @@ class PlotBase2d(PlotBase):
     Base class for plotting tasks creating 2-dimensional plots.
     """
 
+    plot_function_name_2d = luigi.Parameter(
+        default="columnflow.plotting.plot2d.plot_2d",
+        significant=False,
+        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
+    )
     zscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
         default=law.NO_STR,

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -11,7 +11,7 @@ import law
 import luigi
 
 from columnflow.tasks.framework.base import AnalysisTask
-from columnflow.tasks.framework.mixins import CategoriesMixin, DatasetsProcessesMixin
+from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
 from columnflow.util import test_float
 
 
@@ -20,6 +20,11 @@ class PlotBase(AnalysisTask):
     Base class for all plotting tasks.
     """
 
+    plot_function_name = luigi.Parameter(
+        default="",
+        significant=False,
+        description="name of the plot function; empty default",
+    )
     file_types = law.CSVParameter(
         default=("pdf",),
         significant=True,
@@ -153,7 +158,7 @@ def view_output_plots(fn, opts, task, *args, **kwargs):
 PlotBase.view_output_plots = view_output_plots
 
 
-class PlotBase1D(PlotBase):
+class PlotBase1d(PlotBase):
     """
     Base class for plotting tasks creating 1-dimensional plots.
     """
@@ -189,10 +194,9 @@ class PlotBase1D(PlotBase):
         return params
 
 
-class ProcessPlotBase(
-    CategoriesMixin,
+class ProcessPlotSettingMixin(
     DatasetsProcessesMixin,
-    PlotBase1D,
+    PlotBase,
 ):
     """
     Base class for tasks creating plots where contributions of different processes are shown.
@@ -257,7 +261,7 @@ class ProcessPlotBase(
         return parts
 
 
-class PlotBase2D(PlotBase):
+class PlotBase2d(PlotBase):
     """
     Base class for plotting tasks creating 2-dimensional plots.
     """
@@ -266,7 +270,7 @@ class PlotBase2D(PlotBase):
         choices=(law.NO_STR, "linear", "log"),
         default=law.NO_STR,
         significant=False,
-        description="string parameter to define the z-axis scale of the plot in the upper panel; "
+        description="string parameter to define the z-axis scale of the plot; "
         "choices: NO_STR,linear,log; no default",
     )
 

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -138,12 +138,12 @@ class CreateHistograms(
                         )
 
             # define and fill histograms, taking into account multiple axes
-            for key, var_names in self.variable_tuples:
+            for var_key, var_names in self.variable_tuples.items():
                 # get variable instances
                 variable_insts = [self.config_inst.get_variable(var_name) for var_name in var_names]
 
                 # create the histogram if not present yet
-                if key not in histograms:
+                if var_key not in histograms:
                     h = (
                         hist.Hist.new
                         .IntCat([], name="category", growth=True)
@@ -158,7 +158,7 @@ class CreateHistograms(
                             label=variable_inst.get_full_x_title(),
                         )
                     # enable weights and store it
-                    histograms[key] = h.Weight()
+                    histograms[var_key] = h.Weight()
 
                 # broadcast arrays so that each event can be filled for all its categories
                 fill_kwargs = {
@@ -177,7 +177,7 @@ class CreateHistograms(
                     fill_kwargs[variable_inst.name] = expr(events)
                 # broadcast and fill
                 arrays = (ak.flatten(a) for a in ak.broadcast_arrays(*fill_kwargs.values()))
-                histograms[key].fill(**dict(zip(fill_kwargs, arrays)))
+                histograms[var_key].fill(**dict(zip(fill_kwargs, arrays)))
 
         # merge output files
         self.output().dump(histograms, formatter="pickle")

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -137,39 +137,47 @@ class CreateHistograms(
                             f"weight '{column}' for dataset {self.dataset_inst.name} not found",
                         )
 
-            # define and fill histograms
-            for var_name in self.variables:
-                variable_inst = self.config_inst.get_variable(var_name)
+            # define and fill histograms, taking into account multiple axes
+            for key, var_names in self.variable_tuples:
+                # get variable instances
+                variable_insts = [self.config_inst.get_variable(var_name) for var_name in var_names]
 
-                # get the expression and when it's a string, parse it to extract index lookups
-                expr = variable_inst.expression
-                if isinstance(expr, str):
-                    route = Route(expr)
-                    expr = functools.partial(route.apply, null_value=variable_inst.null_value)
-
-                if var_name not in histograms:
-                    histograms[var_name] = (
+                # create the histogram if not present yet
+                if key not in histograms:
+                    h = (
                         hist.Hist.new
                         .IntCat([], name="category", growth=True)
                         .IntCat([], name="process", growth=True)
                         .IntCat([], name="shift", growth=True)
-                        .Var(
+                    )
+                    # add variable axes
+                    for variable_inst in variable_insts:
+                        h = h.Var(
                             variable_inst.bin_edges,
-                            name=var_name,
+                            name=variable_inst.name,
                             label=variable_inst.get_full_x_title(),
                         )
-                        .Weight()
-                    )
+                    # enable weights and store it
+                    histograms[key] = h.Weight()
+
                 # broadcast arrays so that each event can be filled for all its categories
                 fill_kwargs = {
-                    var_name: expr(events),
                     "category": events.category_ids,
                     "process": events.process_id,
                     "shift": self.shift_inst.id,
                     "weight": weight,
                 }
+                for variable_inst in variable_insts:
+                    # prepare the expression
+                    expr = variable_inst.expression
+                    if isinstance(expr, str):
+                        route = Route(expr)
+                        expr = functools.partial(route.apply, null_value=variable_inst.null_value)
+                    # apply it
+                    fill_kwargs[variable_inst.name] = expr(events)
+                # broadcast and fill
                 arrays = (ak.flatten(a) for a in ak.broadcast_arrays(*fill_kwargs.values()))
-                histograms[var_name].fill(**dict(zip(fill_kwargs, arrays)))
+                histograms[key].fill(**dict(zip(fill_kwargs, arrays)))
 
         # merge output files
         self.output().dump(histograms, formatter="pickle")

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -150,16 +150,16 @@ class PlotVariablesBase(
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
-            # determine the correct plot function for this variable (TODO: there is probably a better way to do this?)
-            plot_function_name = self.plot_function_name
-            if len(variable_insts) == 1:
-                if "plot_function_name_1d" in dir(self):
-                    plot_function_name = self.plot_function_name_1d
-            elif len(variable_insts) == 2:
-                if "plot_function_name_2d" in dir(self):
-                    plot_function_name = self.plot_function_name_2d
-            else:
-                raise NotImplementedError("Plotting is only enabled for histograms with 1 or 2 variables")
+            # determine the correct plot function for this variable
+            plot_function_name = (
+                self.plot_function_name_1d if len(variable_insts) == 1 and "plot_function_name_1d" in dir(self) else
+                self.plot_function_name_2d if len(variable_insts) == 2 and "plot_function_name_2d" in dir(self) else
+                None
+            )
+            if not plot_function_name:
+                raise NotImplementedError(
+                    f"No Plotting function for {len(variable_insts)} variables implemented of task {self.cls_name}",
+                )
 
             # call the plot function
             fig = self.call_plot_func(
@@ -181,11 +181,7 @@ class PlotVariables1d(
     ProcessPlotSettingMixin,
 ):
 
-    plot_function_name = luigi.Parameter(
-        default="columnflow.plotting.example.plot_variable_per_process",
-        significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
-    )
+    pass
 
 
 class PlotVariables2d(
@@ -194,34 +190,10 @@ class PlotVariables2d(
     ProcessPlotSettingMixin,
 ):
 
-    plot_function_name = luigi.Parameter(
-        default="columnflow.plotting.plot2d.plot_2d",
-        significant=False,
-        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d''",
-    )
+    pass
 
 
-class PlotVariables(
-    PlotVariablesBase,
-    PlotBase1d,
-    PlotBase2d,
-    ProcessPlotSettingMixin,
-):
-
-    plot_function_name_1d = luigi.Parameter(
-        default="columnflow.plotting.example.plot_variable_per_process",
-        significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
-    )
-
-    plot_function_name_2d = luigi.Parameter(
-        default="columnflow.plotting.plot2d.plot_2d",
-        significant=False,
-        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
-    )
-
-
-class PlotShiftedVariables(
+class PlotShiftedVariables1d(
     VariablesMixin,
     ShiftSourcesMixin,
     MLModelsMixin,
@@ -229,6 +201,7 @@ class PlotShiftedVariables(
     SelectorStepsMixin,
     CalibratorsMixin,
     CategoriesMixin,
+    PlotBase1d,
     ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -152,19 +152,19 @@ class PlotVariablesBase(
             )
 
             # determine the correct plot function for this variable
-            plot_function_name = (
-                self.plot_function_name_1d if len(variable_insts) == 1 and "plot_function_name_1d" in dir(self) else
-                self.plot_function_name_2d if len(variable_insts) == 2 and "plot_function_name_2d" in dir(self) else
+            plot_function = (
+                self.plot_function_1d if len(variable_insts) == 1 and "plot_function_1d" in dir(self) else
+                self.plot_function_2d if len(variable_insts) == 2 and "plot_function_2d" in dir(self) else
                 None
             )
-            if not plot_function_name:
+            if not plot_function:
                 raise NotImplementedError(
                     f"No Plotting function for {len(variable_insts)} variables implemented of task {self.cls_name}",
                 )
 
             # call the plot function
             fig = self.call_plot_func(
-                plot_function_name,
+                plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
                 variable_insts=variable_insts,
@@ -223,9 +223,12 @@ class PlotShiftedVariables1d(
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    # default plot function
-    plot_function_name = "columnflow.plotting.example.plot_shifted_variable"
-
+    # overriding the default plot function
+    plot_function_1d = luigi.Parameter(
+        default="columnflow.plotting.example.plot_shifted_variable",
+        significant=False,
+        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_shifted_variable'",
+    )
     # default upstream dependency task classes
     dep_MergeShiftedHistograms = MergeShiftedHistograms
 
@@ -363,7 +366,7 @@ class PlotShiftedVariables1d(
                 for process_inst, h in hists.items():
                     # call the plot function once per process
                     fig = self.call_plot_func(
-                        self.plot_function_name,
+                        self.plot_function_1d,
                         hists={process_inst: h},
                         config_inst=self.config_inst,
                         variable_inst=variable_inst,
@@ -375,7 +378,7 @@ class PlotShiftedVariables1d(
             else:
                 # call the plot function once
                 fig = self.call_plot_func(
-                    self.plot_function_name,
+                    self.plot_function,
                     hists=hists,
                     config_inst=self.config_inst,
                     variable_inst=variable_inst,

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -17,7 +17,7 @@ from columnflow.tasks.framework.mixins import (
 from columnflow.tasks.framework.plotting import PlotBase, PlotBase1d, PlotBase2d, ProcessPlotSettingMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from columnflow.util import DotDict, dev_sandbox
+from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 
 
 class PlotVariablesBase(
@@ -232,9 +232,7 @@ class PlotShiftedVariables1d(
     def get_plot_parameters(self):
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
-
-        params["legend_title"] = None if self.legend_title == law.NO_STR else self.legend_title
-
+        dict_add_strict(params, "legend_title", None if self.legend_title == law.NO_STR else self.legend_title)
         return params
 
     def store_parts(self):

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -33,6 +33,7 @@ class PlotVariablesBase(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
+    exclude_index = True
 
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -490,9 +490,10 @@ def get_root_processes_from_campaign(campaign: od.Campaign) -> od.UniqueObjectIn
 
 def dict_add_strict(d: dict, key: str, value: Any) -> None:
     """
-    Adds key-value pair to dictionary if not present already; raises Error otherwise.
+    Adds key-value pair to dictionary, but only if it does not change an existing value;
+    Raises KeyError otherwise.
     """
-    if key in d.keys():
+    if key in d.keys() and d[key] != value:
         raise KeyError(f"'{d.__class__.__name__}' object already has key {key}")
     d[key] = value
 

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -530,6 +530,16 @@ class DotDict(OrderedDict):
     def __setattr__(self, attr: str, value: Any) -> None:
         self[attr] = value
 
+    def cautious_update(self, other: dict) -> None:
+        """
+        Updates DotDict, but only if no value is overwritten. Throws error otherwise.
+        """
+        key_replicas = set(self.keys()) & set(other.keys())
+        if not key_replicas:
+            self.update(other)
+        else:
+            raise KeyError(f"'{self.__class__.__name__}' object already has attributes {key_replicas}")
+
     def copy(self) -> DotDict:
         """"""
         return self.__class__(self)

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -488,6 +488,15 @@ def get_root_processes_from_campaign(campaign: od.Campaign) -> od.UniqueObjectIn
     return index
 
 
+def dict_add_strict(d: dict, key: str, value: Any) -> None:
+    """
+    Adds key-value pair to dictionary if not present already; raises Error otherwise.
+    """
+    if key in d.keys():
+        raise KeyError(f"'{d.__class__.__name__}' object already has key {key}")
+    d[key] = value
+
+
 class DotDict(OrderedDict):
     """
     Subclass of *OrderedDict* that provides read and write access to items via attributes by
@@ -529,16 +538,6 @@ class DotDict(OrderedDict):
 
     def __setattr__(self, attr: str, value: Any) -> None:
         self[attr] = value
-
-    def cautious_update(self, other: dict) -> None:
-        """
-        Updates DotDict, but only if no value is overwritten. Throws error otherwise.
-        """
-        key_replicas = set(self.keys()) & set(other.keys())
-        if not key_replicas:
-            self.update(other)
-        else:
-            raise KeyError(f"'{self.__class__.__name__}' object already has attributes {key_replicas}")
 
     def copy(self) -> DotDict:
         """"""


### PR DESCRIPTION
This PR restructures the plotting tasks as shown in the comment below.
The major changes are that the `PlotVariables` task is now separated in two callable tasks,  `PlotVariables1d` and `PlotVariables2d`, which have the same base class but inherit from different base classes to provide different sets of parameters.

The new plotting function is implemented here [1] and uses all plotting parameters enabled for 2d plotting tasks except the `process-settings`.

Example command for `PlotVariables2d`:
```
law run cf.PlotVariables2d --version v1 --processes tt_sl,st_tchannel --variables n_jet_vs_jet1_pt --zscale log --shape-norm True
```
`PlotCutflowVariables2d` is also implemented and working, producing one plot per process and selector-step.


TODOs (for a next PR?):
- we should implement a `per-process` parameter for the 2d tasks to enable switching between producing 1 plot per process or 1 plot with all processes added together. This could also be a part of the `ProcessPlotSettingMixin`.
- use the process_settings in `plot_2d`. Changing plotting label and process scale could be used.
- The plot_function_names in `PlotCutflowVariables1d` are still hard-coded.

[1]