### PR TITLE
Rotate cutflow bin labels to prevent overlap.

### DIFF
--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -467,4 +467,8 @@ def plot_cutflow(
     # ratio plot not used here; set `skip_ratio` to True
     kwargs["skip_ratio"] = True
 
-    return plot_all(plot_config, style_config, **kwargs)
+    p = plot_all(plot_config, style_config, **kwargs)
+
+    plt.gca().set_xticklabels(xticklabels, rotation=45, ha="right")
+
+    return p


### PR DESCRIPTION
The x axis labels in cutflow plots can quickly overlap if the selection step labels get too long, making them difficult to read. This PR proposes a quick fix by drawing the labels at an angle of 45 degrees.