### PR TITLE
Support masks in electron/muon weight producers.

### DIFF
--- a/columnflow/production/btag.py
+++ b/columnflow/production/btag.py
@@ -42,6 +42,9 @@ def btag_weights(
     In addition, JEC uncertainty sources are propagated and weight columns are written if an
     auxiliary config entry ``btag_sf_jec_sources`` exists.
 
+    Optionally, a *jet_mask* can be supplied to compute the scale factor weight
+    based only on a subset of jets.
+
     Resources:
 
        - https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration?rev=26


### PR DESCRIPTION
Allow optional object masks to be passed to the `electron_weight` and `muon_weight` producers. The implementation is completely analogous to the one in `btag_weight`.

Closes #118.