### PR TITLE
Various improvements for plotting tasks/functions

### DIFF
--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -143,9 +143,11 @@ def plot_all(
 
     rax = None
     if not skip_ratio:
-        fig, (ax, rax) = plt.subplots(2, 1, gridspec_kw=dict(height_ratios=[3, 1], hspace=0), sharex=True)
+        fig, axs = plt.subplots(2, 1, gridspec_kw=dict(height_ratios=[3, 1], hspace=0), sharex=True)
+        (ax, rax) = axs
     else:
         fig, ax = plt.subplots()
+        axs = (ax,)
 
     for key, cfg in plot_config.items():
         if "method" not in cfg:
@@ -217,7 +219,7 @@ def plot_all(
 
     plt.tight_layout()
 
-    return fig
+    return fig, axs
 
 
 def plot_variable_per_process(
@@ -478,8 +480,8 @@ def plot_cutflow(
     # ratio plot not used here; set `skip_ratio` to True
     kwargs["skip_ratio"] = True
 
-    p = plot_all(plot_config, style_config, **kwargs)
+    fig, (ax,) = plot_all(plot_config, style_config, **kwargs)
 
-    plt.gca().set_xticklabels(xticklabels, rotation=45, ha="right")
+    ax.set_xticklabels(xticklabels, rotation=45, ha="right")
 
-    return p
+    return fig, (ax,)

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -12,7 +12,7 @@ from typing import Sequence, Iterable
 import law
 
 from columnflow.util import maybe_import, test_float
-from columnflow.plotting.plot_util import prepare_plot_config, remove_residual_axis
+from columnflow.plotting.plot_util import prepare_plot_config, remove_residual_axis, apply_variable_settings
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -230,11 +230,15 @@ def plot_variable_per_process(
     shape_norm: bool | None = False,
     yscale: str | None = "",
     process_settings: dict | None = None,
+    variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
 
     remove_residual_axis(hists, "shift")
+
+    # apply variable_settings
+    hists = apply_variable_settings(hists, variable_settings)
 
     # setup plotting config
     plot_config = prepare_plot_config(hists, shape_norm, process_settings)
@@ -273,11 +277,14 @@ def plot_variable_variants(
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
+    variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
 
     remove_residual_axis(hists, "shift")
+
+    hists = apply_variable_settings(hists, variable_settings)
 
     plot_config = OrderedDict()
 
@@ -333,9 +340,12 @@ def plot_shifted_variable(
     yscale: str | None = None,
     legend_title: str | None = None,
     process_settings: dict | None = None,
+    variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
+
+    hists = apply_variable_settings(hists, variable_settings)
 
     # create the sum of histograms over all processes
     h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
@@ -423,12 +433,15 @@ def plot_cutflow(
     shape_norm: bool = False,
     yscale: str | None = None,
     process_settings: dict | None = None,
+    variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     remove_residual_axis(hists, "shift")
 
     if not process_settings:
         process_settings = {}
+
+    hists = apply_variable_settings(hists, variable_settings)
 
     # setup plotting config
     plot_config = prepare_plot_config(hists, shape_norm, process_settings)

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -12,7 +12,7 @@ from typing import Sequence, Iterable
 import law
 
 from columnflow.util import maybe_import, test_float
-from columnflow.plotting.plot_util import prepare_plot_config
+from columnflow.plotting.plot_util import prepare_plot_config, remove_residual_axis
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -234,16 +234,7 @@ def plot_variable_per_process(
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
 
-    # remove any residual shift axis
-    for key, hist in list(hists.items()):
-        if "shift" in hist.axes.name:
-            n_shifts = len(hist.axes["shift"])
-            if n_shifts != 1:
-                raise Exception(
-                    f"shift axis of histogram for key {key} has {n_shifts} values whereas at most "
-                    "1 is expected",
-                )
-            hists[key] = hist[{"shift": sum}]
+    remove_residual_axis(hists, "shift")
 
     # setup plotting config
     plot_config = prepare_plot_config(hists, shape_norm, process_settings)
@@ -285,6 +276,8 @@ def plot_variable_variants(
     **kwargs,
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
+
+    remove_residual_axis(hists, "shift")
 
     plot_config = OrderedDict()
 
@@ -432,6 +425,8 @@ def plot_cutflow(
     process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
+    remove_residual_axis(hists, "shift")
+
     if not process_settings:
         process_settings = {}
 

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -232,6 +232,17 @@ def plot_variable_per_process(
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
 
+    # remove any residual shift axis
+    for key, hist in list(hists.items()):
+        if "shift" in hist.axes.name:
+            n_shifts = len(hist.axes["shift"])
+            if n_shifts != 1:
+                raise Exception(
+                    f"shift axis of histogram for key {key} has {n_shifts} values whereas at most "
+                    "1 is expected",
+                )
+            hists[key] = hist[{"shift": sum}]
+
     # setup plotting config
     plot_config = prepare_plot_config(hists, shape_norm, process_settings)
 

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -95,4 +95,4 @@ def plot_2d(
 
     h_sum.plot2d(ax=ax, **style_config["plot2d_cfg"])
 
-    return fig
+    return fig, (ax,)

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 import law
 
 from columnflow.util import maybe_import
-from columnflow.plot_util import remove_residual_axis
+from columnflow.plotting.plot_util import remove_residual_axis, apply_variable_settings
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -32,10 +32,13 @@ def plot_2d(
     skip_legend: bool = False,
     skip_cms: bool = False,
     process_settings: dict | None = None,  # TODO use
+    variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     # remove shift axis from histograms
     remove_residual_axis(hists, "shift")
+
+    hists = apply_variable_settings(hists, variable_settings)
 
     # use CMS plotting style
     plt.style.use(mplhep.style.CMS)

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 import law
 
 from columnflow.util import maybe_import
+from columnflow.plot_util import remove_residual_axis
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -33,6 +34,8 @@ def plot_2d(
     process_settings: dict | None = None,  # TODO use
     **kwargs,
 ) -> plt.Figure:
+    # remove shift axis from histograms
+    remove_residual_axis(hists, "shift")
 
     # use CMS plotting style
     plt.style.use(mplhep.style.CMS)

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -18,23 +18,26 @@ od = maybe_import("order")
 
 
 def apply_variable_settings(hists: dict, variable_settings: dict | None = None) -> dict:
+    """
+    applies settings from `variable_settings` dictionary to all histograms in `hists`.
+    """
     # check if there are variable settings to apply
     if not variable_settings:
         return hists
-    relevant_variables = set(list(hists.values())[0].axes.name) & set(variable_settings.keys())
+    relevant_variables = set(list(hists.values())[0].axes.name).intersection(variable_settings.keys())
     if not relevant_variables:
         return hists
 
     # apply all settings
     for var in relevant_variables:
         var_settings = variable_settings[var]
-        for key, h in hists.items():
+        for key, h in list(hists.items()):
             # apply rebinning setting
             rebin_factor = int(var_settings.get("rebin", 1))
             h = h[{var: hist.rebin(rebin_factor)}]
 
             # apply label setting
-            var_label = var_settings.get("label", None)
+            var_label = var_settings.get("label")
             if var_label:
                 h.axes[var].label = var_label
 

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -17,6 +17,23 @@ mplhep = maybe_import("mplhep")
 od = maybe_import("order")
 
 
+def remove_residual_axis(hists: dict, ax_name: str, max_bins: int=1) -> dict:
+    """
+    removes axis named 'ax_name' if existing and there is only a single bin in the axis;
+    raises Exception otherwise
+    """
+    for key, hist in list(hists.items()):
+        if ax_name in hist.axes.name:
+            n_bins = len(hist.axes[ax_name])
+            if n_bins > max_bins:
+                raise Exception(
+                    f"{ax_name} axis of histogram for key {key} has {n_bins} values whereas at most "
+                    "{max_bins} is expected",
+                )
+            hists[key] = hist[{ax_name: sum}]
+
+    return hists
+
 def prepare_plot_config(
     hists: OrderedDict,
     shape_norm: bool | None = False,

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -527,10 +527,11 @@ class PlotCutflowVariables1D(
         b = self.branch_data
         if self.per_plot == "processes":
             return law.SiblingFileCollection({
-                s: [self.local_target(name) for name in self.get_plot_names
-                (
-                    f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}"
-                )]
+                s: [
+                    self.local_target(name) for name in self.get_plot_names(
+                        f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
+                    )
+                ]
                 for i, s in enumerate(self.chosen_steps)
             })
         else:  # per_plot == "steps"
@@ -602,10 +603,11 @@ class PlotCutflowVariables2D(
     def output(self):
         b = self.branch_data
         return law.SiblingFileCollection({
-            s: [self.local_target(name) for name in self.get_plot_names
-            (
-                f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}"
-            )]
+            s: [
+                self.local_target(name) for name in self.get_plot_names(
+                    f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
+                )
+            ]
             for i, s in enumerate(self.chosen_steps)
         })
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -17,6 +17,7 @@ from columnflow.tasks.framework.mixins import (
 from columnflow.tasks.framework.plotting import (
     PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
 )
+from columnflow.tasks.framework.decorators import view_output_plots
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -198,6 +199,11 @@ class PlotCutflow(
     # default upstream dependency task classes
     dep_CreateCutflowHistograms = CreateCutflowHistograms
 
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "plot", f"datasets_{self.datasets_repr}")
+        return parts
+
     def create_branch_map(self):
         # one category per branch
         if not self.categories:
@@ -244,7 +250,7 @@ class PlotCutflow(
         ]
 
     @law.decorator.log
-    @PlotBase.view_output_plots
+    @view_output_plots
     def run(self):
         import hist
 
@@ -370,6 +376,11 @@ class PlotCutflowVariablesBase(
         if self.only_final_step:
             del self.chosen_steps[:-1]
 
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "plot", f"datasets_{self.datasets_repr}")
+        return parts
+
     def create_branch_map(self):
         if not self.categories:
             raise Exception(
@@ -411,7 +422,7 @@ class PlotCutflowVariablesBase(
         pass
 
     @law.decorator.log
-    @PlotBase.view_output_plots
+    @view_output_plots
     def run(self):
         import hist
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -14,7 +14,9 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedReaderMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin
+from columnflow.tasks.framework.plotting import (
+    PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
+)
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -332,7 +334,7 @@ PlotCutflowWrapper = wrapper_factory(
 
 class PlotCutflowVariablesBase(
     ShiftTask,
-    VariablesMixin,
+    VariablePlotSettingMixin,
     SelectorStepsMixin,
     CalibratorsMixin,
     CategoriesMixin,

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -14,7 +14,7 @@ from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedReaderMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, PlotBase1d, PlotBase2d, ProcessPlotSettingMixin
+from columnflow.tasks.framework.plotting import PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.selection import MergeSelectionMasks
 from columnflow.util import dev_sandbox, DotDict
@@ -175,7 +175,7 @@ class PlotCutflow(
     SelectorStepsMixin,
     CalibratorsMixin,
     CategoriesMixin,
-    PlotBase1d,
+    PlotBase1D,
     ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
@@ -483,9 +483,9 @@ class PlotCutflowVariablesBase(
             )
 
 
-class PlotCutflowVariables1d(
+class PlotCutflowVariables1D(
     PlotCutflowVariablesBase,
-    PlotBase1d,
+    PlotBase1D,
     ProcessPlotSettingMixin,
 ):
 
@@ -570,9 +570,9 @@ class PlotCutflowVariables1d(
                     outp.dump(fig, formatter="mpl")
 
 
-class PlotCutflowVariables2d(
+class PlotCutflowVariables2D(
     PlotCutflowVariablesBase,
-    PlotBase2d,
+    PlotBase2D,
     ProcessPlotSettingMixin,
 ):
 
@@ -610,9 +610,9 @@ class PlotCutflowVariables2d(
                 outp.dump(fig, formatter="mpl")
 
 
-class PlotCutflowVariablesPerProcess2d(
+class PlotCutflowVariablesPerProcess2D(
     law.WrapperTask,
-    PlotCutflowVariables2d,
+    PlotCutflowVariables2D,
 ):
 
     # force this one to be a local workflow
@@ -620,6 +620,6 @@ class PlotCutflowVariablesPerProcess2d(
 
     def requires(self):
         return {
-            process: PlotCutflowVariables2d.req(self, processes=(process,))
+            process: PlotCutflowVariables2D.req(self, processes=(process,))
             for process in self.processes
         }

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -506,17 +506,17 @@ class PlotCutflowVariables1D(
         b = self.branch_data
         if self.per_plot == "processes":
             return law.SiblingFileCollection({
-                s: [
-                    self.local_target(name)
-                    for name in self.get_plot_names(f"plot__cat_{b.category}__var_{b.variable}__step{i}_{s}")
-                ]
+                s: [self.local_target(name) for name in self.get_plot_names
+                (
+                    f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}"
+                )]
                 for i, s in enumerate(self.chosen_steps)
             })
         else:  # per_plot == "steps"
             return law.SiblingFileCollection({
                 p: [
                     self.local_target(name)
-                    for name in self.get_plot_names(f"plot__cat_{b.category}__var_{b.variable}__proc_{p}")
+                    for name in self.get_plot_names(f"plot__proc_{p}__cat_{b.category}__var_{b.variable}")
                 ]
                 for p in self.processes
             })
@@ -581,10 +581,10 @@ class PlotCutflowVariables2D(
     def output(self):
         b = self.branch_data
         return law.SiblingFileCollection({
-            s: [
-                self.local_target(name)
-                for name in self.get_plot_names(f"plot__cat_{b.category}__var_{b.variable}__step{i}_{s}")
-            ]
+            s: [self.local_target(name) for name in self.get_plot_names
+            (
+                f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}"
+            )]
             for i, s in enumerate(self.chosen_steps)
         })
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -401,10 +401,10 @@ class PlotCutflowVariablesBase(
         }
 
     def output(self):
-        # To be implemented by daughter tasks
+        # to be implemented by daughter tasks
         return None
 
-    def run_postprocess(self, hists, variable_insts, process_insts):
+    def run_postprocess(self, hists, variable_insts):
         # to be implemented by daughter tasks
         pass
 
@@ -480,7 +480,6 @@ class PlotCutflowVariablesBase(
             self.run_postprocess(
                 hists=hists,
                 variable_insts=variable_insts,
-                process_insts=process_insts,  # TODO: should be manageable to remove
             )
 
 
@@ -520,7 +519,7 @@ class PlotCutflowVariables1d(
                 for p in self.processes
             })
 
-    def run_postprocess(self, hists, variable_insts, process_insts):
+    def run_postprocess(self, hists, variable_insts):
         import hist
 
         if len(variable_insts) != 1:
@@ -531,8 +530,8 @@ class PlotCutflowVariables1d(
             for step in self.chosen_steps:
                 # sort hists by process order
                 step_hists = OrderedDict(
-                    (process_inst, hists[process_inst][{"step": hist.loc(step)}])
-                    for process_inst in sorted(hists, key=process_insts.index)
+                    (process_inst, h[{"step": h.loc(step)}])
+                    for process_inst, h in hists.items()
                 )
 
                 # call the plot function
@@ -590,7 +589,7 @@ class PlotCutflowVariables2d(
         }
         return law.SiblingFileCollection(outp)
 
-    def run_postprocess(self, hists, variable_insts, process_insts):
+    def run_postprocess(self, hists, variable_insts):
         import hist
 
         if len(variable_insts) != 2:

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -325,7 +325,7 @@ class PlotCutflow(
             )
 
             # call the plot function
-            fig = self.call_plot_func(
+            fig, _ = self.call_plot_func(
                 self.plot_function_1d,
                 hists=hists,
                 config_inst=self.config_inst,
@@ -558,7 +558,7 @@ class PlotCutflowVariables1D(
                 )
 
                 # call the plot function
-                fig = self.call_plot_func(
+                fig, _ = self.call_plot_func(
                     self.plot_function_per_process,
                     hists=step_hists,
                     config_inst=self.config_inst,
@@ -579,7 +579,7 @@ class PlotCutflowVariables1D(
                 )
 
                 # call the plot function
-                fig = self.call_plot_func(
+                fig, _ = self.call_plot_func(
                     self.plot_function_per_step,
                     hists=process_hists,
                     config_inst=self.config_inst,
@@ -619,7 +619,7 @@ class PlotCutflowVariables2D(
 
         for step in self.chosen_steps:
             # call the plot function
-            fig = self.call_plot_func(
+            fig, _ = self.call_plot_func(
                 self.plot_function_2d,
                 hists=hists[{"step": hist.loc(step)}],
                 config_inst=self.config_inst,

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -317,7 +317,7 @@ class PlotCutflow(
                     }]
 
                     # axis reductions
-                    h = h[{"process": sum, "category": sum, "shift": sum, "mc_weight": sum}]
+                    h = h[{"process": sum, "category": sum, "mc_weight": sum}]
 
                     # add the histogram
                     if process_inst in hists:
@@ -477,7 +477,7 @@ class PlotCutflowVariablesBase(
                     }]
 
                     # axis reductions
-                    h = h[{"process": sum, "category": sum, "shift": sum}]
+                    h = h[{"process": sum, "category": sum}]
 
                     # add the histogram
                     if process_inst in hists:

--- a/columnflow/tasks/framework/decorators.py
+++ b/columnflow/tasks/framework/decorators.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+"""
+Custom law task method decorators.
+"""
+
+import law
+
+
+@law.decorator.factory(accept_generator=True)
+def view_output_plots(fn, opts, task, *args, **kwargs):
+    def before_call():
+        return None
+
+    def call(state):
+        return fn(task, *args, **kwargs)
+
+    def after_call(state):
+        view_cmd = getattr(task, "view_cmd", None)
+        if not view_cmd or view_cmd == law.NO_STR:
+            return
+
+        # prepare the view command
+        if "{}" not in view_cmd:
+            view_cmd += " {}"
+
+        # collect all paths to view
+        view_paths = []
+        outputs = law.util.flatten(task.output())
+        while outputs:
+            output = outputs.pop(0)
+            if isinstance(output, law.TargetCollection):
+                outputs.extend(output._flat_target_list)
+                continue
+            if not getattr(output, "path", None):
+                continue
+            if output.path.endswith((".pdf", ".png")):
+                if not isinstance(output, law.LocalTarget):
+                    task.logger.warning(f"cannot show non-local plot at '{output.path}'")
+                    continue
+                elif output.path not in view_paths:
+                    view_paths.append(output.path)
+
+        # loop through paths and view them
+        for path in view_paths:
+            task.publish_message("showing {}".format(path))
+            law.util.interruptable_popen(view_cmd.format(path), shell=True, executable="/bin/bash")
+
+    return before_call, call, after_call

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -636,7 +636,9 @@ class VariablesMixin(ConfigTask):
                 for parts in multi_var_parts:
                     resolved_parts = [
                         cls.find_config_objects(
-                            part, config_inst, od.Variable,
+                            part,
+                            config_inst,
+                            od.Variable,
                             config_inst.x("variable_groups", {}),
                         )
                         for part in parts

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -4,8 +4,6 @@
 Custom luigi parameters.
 """
 
-from typing import Union
-
 import law
 from columnflow.util import test_float
 
@@ -15,7 +13,7 @@ class SettingsParameterBase():
     Base class to implement class methods for different types of setting parameters.
     """
     @classmethod
-    def parse_setting(self, setting: str) -> tuple[str, Union[float, bool, str]]:
+    def parse_setting(cls, setting: str) -> tuple[str, float | bool | str]:
         pair = setting.split("=", 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
         if test_float(value):
@@ -27,7 +25,7 @@ class SettingsParameterBase():
         return (key, value)
 
     @classmethod
-    def serialize_setting(self, name: str, value: str) -> str:
+    def serialize_setting(cls, name: str, value: str) -> str:
         return f"{name}={value}"
 
 

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -4,27 +4,34 @@
 Custom luigi parameters.
 """
 
+from typing import Union
+
 import law
 from columnflow.util import test_float
 
 
-def parse_setting(setting: str):
-    pair = setting.split("=", 1)
-    key, value = pair if len(pair) == 2 else (pair[0], "True")
-    if test_float(value):
-        value = float(value)
-    elif value.lower() == "true":
-        value = True
-    elif value.lower() == "false":
-        value = False
-    return (key, value)
+class SettingsParameterBase():
+    """
+    Base class to implement class methods for different types of setting parameters.
+    """
+    @classmethod
+    def parse_setting(self, setting: str) -> tuple[str, Union[float, bool, str]]:
+        pair = setting.split("=", 1)
+        key, value = pair if len(pair) == 2 else (pair[0], "True")
+        if test_float(value):
+            value = float(value)
+        elif value.lower() == "true":
+            value = True
+        elif value.lower() == "false":
+            value = False
+        return (key, value)
+
+    @classmethod
+    def serialize_setting(self, name: str, value: str) -> str:
+        return f"{name}={value}"
 
 
-def serialize_setting(name, value):
-    return f"{name}={value}"
-
-
-class SettingsParameter(law.CSVParameter):
+class SettingsParameter(SettingsParameterBase, law.CSVParameter):
     r"""
     Parameter that parses the input of a CSVParameter into a dictionary
 
@@ -41,16 +48,16 @@ class SettingsParameter(law.CSVParameter):
     def parse(self, inp):
         inputs = super().parse(inp)
 
-        return dict(map(parse_setting, inputs))
+        return dict(map(self.parse_setting, inputs))
 
     def serialize(self, value):
         if isinstance(value, dict):
-            value = tuple(serialize_setting(*tpl) for tpl in value.items())
+            value = tuple(self.serialize_setting(*tpl) for tpl in value.items())
 
         return super().serialize(value)
 
 
-class MultiSettingsParameter(law.MultiCSVParameter):
+class MultiSettingsParameter(SettingsParameterBase, law.MultiCSVParameter):
     r"""
     Parameter that parses the input of a MultiCSVParameter into a double-dict structure.
 
@@ -68,7 +75,7 @@ class MultiSettingsParameter(law.MultiCSVParameter):
         inputs = super().parse(inp)
 
         outputs = {
-            settings[0]: dict(map(parse_setting, settings[1:]))
+            settings[0]: dict(map(self.parse_setting, settings[1:]))
             for settings in inputs
         }
 
@@ -77,7 +84,7 @@ class MultiSettingsParameter(law.MultiCSVParameter):
     def serialize(self, value):
         if isinstance(value, dict):
             value = tuple(
-                (str(k),) + tuple(serialize_setting(*tpl) for tpl in v.items())
+                (str(k),) + tuple(self.serialize_setting(*tpl) for tpl in v.items())
                 for k, v in value.items()
             )
 

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Parameters
+Custom luigi parameters.
 """
 
 import law
@@ -17,8 +17,8 @@ class SettingsParameter(law.MultiCSVParameter):
 
         p = SettingsParameter()
         p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false")
-        # => {"obj1": {"k1": 10, "k2": True, "k3": "text"}, {"obj2": {"k4": False}}}
-        p.serialize("{"obj1": {"k1": "val"}, obj2: {"k2": 2}}")
+        # => {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, {"obj2": {"k4": False}}}
+        p.serialize({"obj1": {"k1": "val"}, "obj2": {"k2": 2}})
         # => "obj1,k1=val:obj2,k2=2"
     """
     def parse(self, inp):

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+
+"""
+Parameters
+"""
+
+import law
+from columnflow.util import test_float
+
+
+class SettingsParameter(law.MultiCSVParameter):
+    r"""
+
+    Example:
+
+    .. code-block:: python
+
+        p = SettingsParameter()
+        p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false")
+        # => {"obj1": {"k1": 10, "k2": True, "k3": "text"}, {"obj2": {"k4": False}}}
+        p.serialize("{"obj1": {"k1": "val"}, obj2: {"k2": 2}}")
+        # => "obj1,k1=val:obj2,k2=2"
+    """
+    def parse(self, inp):
+        inputs = super().parse(inp)
+
+        def parse_setting(setting: str):
+            pair = setting.split("=", 1)
+            key, value = pair if len(pair) == 2 else (pair[0], "True")
+            if test_float(value):
+                value = float(value)
+            elif value.lower() == "true":
+                value = True
+            elif value.lower() == "false":
+                value = False
+            return (key, value)
+
+        outputs = {
+            settings[0]: dict(map(parse_setting, settings[1:]))
+            for settings in inputs
+        }
+
+        return outputs
+
+    def serialize(self, value):
+        if isinstance(value, dict):
+            def serialize_setting(name, value):
+                return f"{name}={value}"
+            value = tuple(
+                (str(k),) + tuple(serialize_setting(*tpl) for tpl in v.items())
+                for k, v in value.items()
+            )
+
+        return super().serialize(value)

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -8,14 +8,57 @@ import law
 from columnflow.util import test_float
 
 
-class SettingsParameter(law.MultiCSVParameter):
+def parse_setting(setting: str):
+    pair = setting.split("=", 1)
+    key, value = pair if len(pair) == 2 else (pair[0], "True")
+    if test_float(value):
+        value = float(value)
+    elif value.lower() == "true":
+        value = True
+    elif value.lower() == "false":
+        value = False
+    return (key, value)
+
+
+def serialize_setting(name, value):
+    return f"{name}={value}"
+
+
+class SettingsParameter(law.CSVParameter):
     r"""
+    Parameter that parses the input of a CSVParameter into a dictionary
 
     Example:
 
     .. code-block:: python
 
         p = SettingsParameter()
+        p.parse("param1=10,param2,param3=text,param4=false")
+        => {"param1": 10.0, "param2": True, "param3": "text", "param4": False}
+        p.serialize({"param1": 2, "param2": False})
+        => "param1=2.0,param2=False"
+    """
+    def parse(self, inp):
+        inputs = super().parse(inp)
+
+        return dict(map(parse_setting, inputs))
+
+    def serialize(self, value):
+        if isinstance(value, dict):
+            value = tuple(serialize_setting(*tpl) for tpl in value.items())
+
+        return super().serialize(value)
+
+
+class MultiSettingsParameter(law.MultiCSVParameter):
+    r"""
+    Parameter that parses the input of a MultiCSVParameter into a double-dict structure.
+
+    Example:
+
+    .. code-block:: python
+
+        p = MultiSettingsParameter()
         p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false")
         # => {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, {"obj2": {"k4": False}}}
         p.serialize({"obj1": {"k1": "val"}, "obj2": {"k2": 2}})
@@ -23,17 +66,6 @@ class SettingsParameter(law.MultiCSVParameter):
     """
     def parse(self, inp):
         inputs = super().parse(inp)
-
-        def parse_setting(setting: str):
-            pair = setting.split("=", 1)
-            key, value = pair if len(pair) == 2 else (pair[0], "True")
-            if test_float(value):
-                value = float(value)
-            elif value.lower() == "true":
-                value = True
-            elif value.lower() == "false":
-                value = False
-            return (key, value)
 
         outputs = {
             settings[0]: dict(map(parse_setting, settings[1:]))
@@ -44,8 +76,6 @@ class SettingsParameter(law.MultiCSVParameter):
 
     def serialize(self, value):
         if isinstance(value, dict):
-            def serialize_setting(name, value):
-                return f"{name}={value}"
             value = tuple(
                 (str(k),) + tuple(serialize_setting(*tpl) for tpl in v.items())
                 for k, v in value.items()

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -151,7 +151,7 @@ def view_output_plots(fn, opts, task, *args, **kwargs):
 PlotBase.view_output_plots = view_output_plots
 
 
-class PlotBase1d(PlotBase):
+class PlotBase1D(PlotBase):
     """
     Base class for plotting tasks creating 1-dimensional plots.
     """
@@ -159,7 +159,7 @@ class PlotBase1d(PlotBase):
     plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_variable_per_process",
         significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
+        description="name of the 1D plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
     )
     skip_ratio = luigi.BoolParameter(
         default=False,
@@ -265,15 +265,15 @@ class ProcessPlotSettingMixin(
         return parts
 
 
-class PlotBase2d(PlotBase):
+class PlotBase2D(PlotBase):
     """
     Base class for plotting tasks creating 2-dimensional plots.
     """
 
-    plot_function_2d = luigi.Parameter(
+    plot_function_2D = luigi.Parameter(
         default="columnflow.plotting.plot2d.plot_2d",
         significant=False,
-        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
+        description="name of the 2D plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
     )
     zscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -208,6 +208,12 @@ class ProcessPlotSettingMixin(
         brace_expand=True,
     )
 
+    per_process = luigi.BoolParameter(
+        default=False,
+        significant=True,
+        description="when True, one plot per process is produced; default: False",
+    )
+
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -160,7 +160,7 @@ class PlotBase1D(PlotBase):
     plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_variable_per_process",
         significant=False,
-        description="name of the 1D plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
+        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
     )
     skip_ratio = luigi.BoolParameter(
         default=False,
@@ -196,10 +196,10 @@ class PlotBase2D(PlotBase):
     Base class for plotting tasks creating 2-dimensional plots.
     """
 
-    plot_function_2D = luigi.Parameter(
+    plot_function_2d = luigi.Parameter(
         default="columnflow.plotting.plot2d.plot_2d",
         significant=False,
-        description="name of the 2D plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
+        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
     )
     zscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
@@ -287,7 +287,7 @@ class ProcessPlotSettingMixin(
 
     def store_parts(self):
         parts = super().store_parts()
-        part = f"datasets_{self.datasets_repr}__processes_{self.processes_repr}"
+        part = f"datasets_{self.datasets_repr}"
         parts.insert_before("version", "plot", part)
         return parts
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -38,18 +38,18 @@ class PlotBase(ConfigTask):
         "terminal; no default",
     )
     general_settings = SettingsParameter(
-        default=(),
+        default=DotDict(),
         significant=False,
         description="Parameter to set a list of custom plotting parameters. Format: "
         "'option1=val1,option2=val2,...'",
     )
-    skip_legend = luigi.BoolParameter(
-        default=False,
+    skip_legend = law.OptionalBoolParameter(
+        default=None,
         significant=False,
         description="when True, no legend is drawn; default: False",
     )
-    skip_cms = luigi.BoolParameter(
-        default=False,
+    skip_cms = law.OptionalBoolParameter(
+        default=None,
         significant=False,
         description="when True, no CMS logo is drawn; default: False",
     )
@@ -153,13 +153,14 @@ class PlotBase1D(PlotBase):
     plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_variable_per_process",
         significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_variable_per_process'",
+        description="name of the 1d plot function; default: "
+        "columnflow.plotting.example.plot_variable_per_process",
     )
-    skip_ratio = luigi.BoolParameter(
-        default=False,
+    skip_ratio = law.OptionalBoolParameter(
+        default=None,
         significant=False,
         description="when True, no ratio (usually Data/Bkg ratio) is drawn in the lower panel; "
-        "default: False",
+        "default: None",
     )
     yscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
@@ -168,11 +169,11 @@ class PlotBase1D(PlotBase):
         description="string parameter to define the y-axis scale of the plot in the upper panel; "
         "choices: NO_STR,linear,log; no default",
     )
-    shape_norm = luigi.BoolParameter(
-        default=False,
+    shape_norm = law.OptionalBoolParameter(
+        default=None,
         significant=False,
         description="when True, each process is normalized on it's integral in the upper panel; "
-        "default: False",
+        "default: None",
     )
 
     def get_plot_parameters(self) -> DotDict:
@@ -192,7 +193,7 @@ class PlotBase2D(PlotBase):
     plot_function_2d = luigi.Parameter(
         default="columnflow.plotting.plot2d.plot_2d",
         significant=False,
-        description="name of the 2d plot function; default: 'columnflow.plotting.plot2d.plot_2d'",
+        description="name of the 2d plot function; default: columnflow.plotting.plot2d.plot_2d",
     )
     zscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
@@ -201,11 +202,11 @@ class PlotBase2D(PlotBase):
         description="string parameter to define the z-axis scale of the plot; "
         "choices: NO_STR,linear,log; no default",
     )
-    shape_norm = luigi.BoolParameter(
-        default=False,
+    shape_norm = law.OptionalBoolParameter(
+        default=None,
         significant=False,
         description="when True, the overall bin content is normalized on its integral; "
-        "default: False",
+        "default: None",
     )
 
     def get_plot_parameters(self) -> DotDict:
@@ -225,9 +226,9 @@ class ProcessPlotSettingMixin(
     """
 
     process_settings = MultiSettingsParameter(
-        default=(),
+        default=DotDict(),
         significant=False,
-        description="parameter for changing different process settings; Format: "
+        description="parameter for changing different process settings; format: "
         "'process1,option1=value1,option3=value3:process2,option2=value2'; options implemented: "
         "scale, unstack, label; can also be the key of a mapping defined in 'process_settings_groups; "
         "default: value of the 'default_process_settings' if defined, else empty default",
@@ -278,9 +279,9 @@ class VariablePlotSettingMixin(
     """
 
     variable_settings = MultiSettingsParameter(
-        default=(),
+        default=DotDict(),
         significant=False,
-        description="parameter for changing different variable settings; Format: "
+        description="parameter for changing different variable settings; format: "
         "'var1,option1=value1,option3=value3:var2,option2=value2'; options implemented: "
         "rebin; can also be the key of a mapping defined in 'variable_settings_groups; "
         "default: value of the 'default_variable_settings' if defined, else empty default",

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -5,6 +5,7 @@ Tasks to plot different types of histograms.
 """
 
 from collections import OrderedDict
+from abc import abstractmethod
 
 import law
 import luigi
@@ -17,14 +18,15 @@ from columnflow.tasks.framework.mixins import (
 from columnflow.tasks.framework.plotting import (
     PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
 )
+from columnflow.tasks.framework.decorators import view_output_plots
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 
 
 class PlotVariablesBase(
-    ShiftTask,
     VariablePlotSettingMixin,
+    ProcessPlotSettingMixin,
     MLModelsMixin,
     ProducersMixin,
     SelectorStepsMixin,
@@ -35,21 +37,14 @@ class PlotVariablesBase(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
-    exclude_index = True
-
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    shifts = set(MergeHistograms.shifts)
+    exclude_index = True
 
-    # default upstream dependency task classes
-    dep_MergeHistograms = MergeHistograms
-
-    def create_branch_map(self):
-        return [
-            DotDict({"category": cat_name, "variable": var_name})
-            for var_name in self.variables
-            for cat_name in self.categories
-        ]
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "plot", f"datasets_{self.datasets_repr}")
+        return parts
 
     def workflow_requires(self, only_super: bool = False):
         reqs = super().workflow_requires()
@@ -60,29 +55,17 @@ class PlotVariablesBase(
 
         return reqs
 
-    def requires(self):
-        return {
-            d: self.dep_MergeHistograms.req(
-                self,
-                dataset=d,
-                branch=-1,
-                _exclude={"branches"},
-                _prefer_cli={"variables"},
-            )
-            for d in self.datasets
-        }
-
-    def output(self):
-        b = self.branch_data
-        return [
-            self.target(name)
-            for name in self.get_plot_names(f"plot__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}")
-        ]
+    @abstractmethod
+    def get_plot_shifts(self):
+        return
 
     @law.decorator.log
-    @PlotBase.view_output_plots
+    @view_output_plots
     def run(self):
         import hist
+
+        # get the shifts to extract and plot
+        plot_shifts = law.util.make_list(self.get_plot_shifts())
 
         # prepare config objects
         variable_tuple = self.variable_tuples[self.branch_data.variable]
@@ -106,11 +89,6 @@ class PlotVariablesBase(
                 dataset_inst = self.config_inst.get_dataset(dataset)
                 h_in = inp["collection"][0].targets[self.branch_data.variable].load(formatter="pickle")
 
-                # sanity checks
-                n_shifts = len(h_in.axes["shift"])
-                if n_shifts != 1:
-                    raise Exception(f"shift axis is supposed to only contain 1 bin, found {n_shifts}")
-
                 # loop and extract one histogram per process
                 for process_inst in process_insts:
                     # skip when the dataset is already known to not contain any sub process
@@ -132,10 +110,15 @@ class PlotVariablesBase(
                             for c in leaf_category_insts
                             if c.id in h.axes["category"]
                         ],
+                        "shift": [
+                            hist.loc(s.id)
+                            for s in plot_shifts
+                            if s.id in h.axes["shift"]
+                        ],
                     }]
 
                     # axis reductions
-                    h = h[{"process": sum, "category": sum, "shift": sum}]
+                    h = h[{"process": sum, "category": sum}]
 
                     # add the histogram
                     if process_inst in hists:
@@ -178,21 +161,58 @@ class PlotVariablesBase(
                 outp.dump(fig, formatter="mpl")
 
 
-class PlotVariables1D(
+class PlotVariablesBaseSingleShift(
+    ShiftTask,
     PlotVariablesBase,
-    PlotBase1D,
-    ProcessPlotSettingMixin,
 ):
+    shifts = set(MergeHistograms.shifts)
 
+    # default upstream dependency task classes
+    dep_MergeHistograms = MergeHistograms
+
+    exclude_index = True
+
+    def create_branch_map(self):
+        return [
+            DotDict({"category": cat_name, "variable": var_name})
+            for var_name in self.variables
+            for cat_name in self.categories
+        ]
+
+    def requires(self):
+        return {
+            d: self.dep_MergeHistograms.req(
+                self,
+                dataset=d,
+                branch=-1,
+                _exclude={"branches"},
+                _prefer_cli={"variables"},
+            )
+            for d in self.datasets
+        }
+
+    def output(self):
+        b = self.branch_data
+        return [
+            self.target(name)
+            for name in self.get_plot_names(f"plot__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}")
+        ]
+
+    def get_plot_shifts(self):
+        return [self.shift_inst]
+
+
+class PlotVariables1D(
+    PlotVariablesBaseSingleShift,
+    PlotBase1D,
+):
     pass
 
 
 class PlotVariables2D(
-    PlotVariablesBase,
+    PlotVariablesBaseSingleShift,
     PlotBase2D,
-    ProcessPlotSettingMixin,
 ):
-
     pass
 
 
@@ -200,7 +220,6 @@ class PlotVariablesPerProcess2D(
     law.WrapperTask,
     PlotVariables2D,
 ):
-
     # force this one to be a local workflow
     workflow = "local"
 
@@ -211,48 +230,26 @@ class PlotVariablesPerProcess2D(
         }
 
 
-class PlotShiftedVariables1D(
-    VariablePlotSettingMixin,
+class PlotVariablesBaseMultiShifts(
     ShiftSourcesMixin,
-    MLModelsMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
-    CategoriesMixin,
-    PlotBase1D,
-    ProcessPlotSettingMixin,
-    law.LocalWorkflow,
-    RemoteWorkflow,
+    PlotVariablesBase,
 ):
-
     legend_title = luigi.Parameter(
         default=law.NO_STR,
         significant=False,
         description="sets the title of the legend; when empty and only one process is present in "
         "the plot, the process_inst label is used; empty default",
     )
-    # overriding the default plot function
     plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_shifted_variable",
         significant=False,
         description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_shifted_variable'",
     )
 
-    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
-
     # default upstream dependency task classes
     dep_MergeShiftedHistograms = MergeShiftedHistograms
 
-    def get_plot_parameters(self):
-        # convert parameters to usable values during plotting
-        params = super().get_plot_parameters()
-        dict_add_strict(params, "legend_title", None if self.legend_title == law.NO_STR else self.legend_title)
-        return params
-
-    def store_parts(self):
-        parts = super().store_parts()
-        parts["plot"] += f"__shifts_{self.shift_sources_repr}"
-        return parts
+    exclude_index = True
 
     def create_branch_map(self):
         return [
@@ -261,14 +258,6 @@ class PlotShiftedVariables1D(
             for cat_name in self.categories
             for source in self.shift_sources
         ]
-
-    def workflow_requires(self, only_super: bool = False):
-        reqs = super().workflow_requires()
-        if only_super:
-            return reqs
-
-        reqs["merged_hists"] = self.requires_from_branch()
-        return reqs
 
     def requires(self):
         return {
@@ -284,99 +273,37 @@ class PlotShiftedVariables1D(
 
     def output(self):
         b = self.branch_data
-        return [self.target(name) for name in self.get_plot_names
-        (
-            f"plot__proc_{self.processes_repr}__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}"
-        )]
+        return [
+            self.target(name)
+            for name in self.get_plot_names(
+                f"plot__proc_{self.processes_repr}__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}",
+            )
+        ]
 
-    @law.decorator.log
-    @PlotBase.view_output_plots
-    def run(self):
-        import hist
-
-        # prepare config objects
-        variable_inst = self.config_inst.get_variable(self.branch_data.variable)
-        category_inst = self.config_inst.get_category(self.branch_data.category)
-        shift_insts = [
+    def get_plot_shifts(self):
+        return [
             self.config_inst.get_shift(s) for s in
             ["nominal", f"{self.branch_data.shift_source}_up", f"{self.branch_data.shift_source}_down"]
         ]
-        leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
-        process_insts = list(map(self.config_inst.get_process, self.processes))
-        sub_process_insts = {
-            proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
-            for proc in process_insts
-        }
 
-        # histogram data per process
-        hists = OrderedDict()
-        outputs = self.output()
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        params = super().get_plot_parameters()
+        dict_add_strict(params, "legend_title", None if self.legend_title == law.NO_STR else self.legend_title)
+        return params
 
-        with self.publish_step(f"plotting {variable_inst.name} in {category_inst.name}"):
-            for dataset, inp in self.input().items():
-                dataset_inst = self.config_inst.get_dataset(dataset)
-                h_in = inp["collection"][0].targets[variable_inst.name].load(formatter="pickle")
 
-                # loop and extract one histogram per process
-                for process_inst in process_insts:
-                    # skip when the dataset is already known to not contain any sub process
-                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
-                        continue
-
-                    # work on a copy
-                    h = h_in.copy()
-
-                    # axis selections
-                    h = h[{
-                        "process": [
-                            hist.loc(p.id)
-                            for p in sub_process_insts[process_inst]
-                            if p.id in h.axes["process"]
-                        ],
-                        "category": [
-                            hist.loc(c.id)
-                            for c in leaf_category_insts
-                            if c.id in h.axes["category"]
-                        ],
-                        "shift": [
-                            hist.loc(s.id)
-                            for s in shift_insts
-                            if s.id in h.axes["shift"]
-                        ],
-                    }]
-
-                    # axis reductions
-                    h = h[{"process": sum, "category": sum}]
-
-                    # add the histogram
-                    if process_inst in hists:
-                        hists[process_inst] += h
-                    else:
-                        hists[process_inst] = h
-
-            # there should be hists to plot
-            if not hists:
-                raise Exception("no histograms found to plot")
-
-            # call the plot function once
-            fig = self.call_plot_func(
-                self.plot_function,
-                hists=hists,
-                config_inst=self.config_inst,
-                variable_inst=variable_inst,
-                **self.get_plot_parameters(),
-            )
-
-            # save the plot
-            for outp in outputs:
-                outp.dump(fig, formatter="mpl")
+class PlotShiftedVariables1D(
+    PlotVariablesBaseMultiShifts,
+    PlotBase1D,
+):
+    pass
 
 
 class PlotShiftedVariablesPerProcess1D(
     law.WrapperTask,
     PlotShiftedVariables1D,
 ):
-
     # force this one to be a local workflow
     workflow = "local"
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -194,6 +194,21 @@ class PlotVariables2d(
     pass
 
 
+class PlotVariablesPerProcess2d(
+    law.WrapperTask,
+    PlotVariables2d,
+):
+
+    # force this one to be a local workflow
+    workflow = "local"
+
+    def requires(self):
+        return {
+            process: PlotVariables2d.req(self, processes=(process,))
+            for process in self.processes
+        }
+
+
 class PlotShiftedVariables1d(
     VariablesMixin,
     ShiftSourcesMixin,

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -164,7 +164,7 @@ class PlotVariablesBase(
                 )
 
             # call the plot function
-            fig = self.call_plot_func(
+            fig, _ = self.call_plot_func(
                 plot_function,
                 hists=hists,
                 config_inst=self.config_inst,

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -76,7 +76,7 @@ class PlotVariablesBase(
         b = self.branch_data
         return [
             self.target(name)
-            for name in self.get_plot_names(f"plot__cat_{b.category}__var_{b.variable}")
+            for name in self.get_plot_names(f"plot__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}")
         ]
 
     @law.decorator.log
@@ -161,7 +161,7 @@ class PlotVariablesBase(
             )
             if not plot_function:
                 raise NotImplementedError(
-                    f"No Plotting function for {len(variable_insts)} variables implemented of task {self.cls_name}",
+                    f"No Plotting function for {len(variable_insts)} variables implemented of task {self.task_family}",
                 )
 
             # call the plot function
@@ -284,10 +284,10 @@ class PlotShiftedVariables1D(
 
     def output(self):
         b = self.branch_data
-        return [
-            self.target(name)
-            for name in self.get_plot_names(f"plot__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}")
-        ]
+        return [self.target(name) for name in self.get_plot_names
+        (
+            f"plot__proc_{self.processes_repr}__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}"
+        )]
 
     @law.decorator.log
     @PlotBase.view_output_plots

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -14,7 +14,7 @@ from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
     VariablesMixin, CategoriesMixin, ShiftSourcesMixin, EventWeightMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, PlotBase1d, PlotBase2d, ProcessPlotSettingMixin
+from columnflow.tasks.framework.plotting import PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import DotDict, dev_sandbox, dict_add_strict
@@ -176,27 +176,27 @@ class PlotVariablesBase(
                 outp.dump(fig, formatter="mpl")
 
 
-class PlotVariables1d(
+class PlotVariables1D(
     PlotVariablesBase,
-    PlotBase1d,
+    PlotBase1D,
     ProcessPlotSettingMixin,
 ):
 
     pass
 
 
-class PlotVariables2d(
+class PlotVariables2D(
     PlotVariablesBase,
-    PlotBase2d,
+    PlotBase2D,
     ProcessPlotSettingMixin,
 ):
 
     pass
 
 
-class PlotVariablesPerProcess2d(
+class PlotVariablesPerProcess2D(
     law.WrapperTask,
-    PlotVariables2d,
+    PlotVariables2D,
 ):
 
     # force this one to be a local workflow
@@ -204,12 +204,12 @@ class PlotVariablesPerProcess2d(
 
     def requires(self):
         return {
-            process: PlotVariables2d.req(self, processes=(process,))
+            process: PlotVariables2D.req(self, processes=(process,))
             for process in self.processes
         }
 
 
-class PlotShiftedVariables1d(
+class PlotShiftedVariables1D(
     VariablesMixin,
     ShiftSourcesMixin,
     MLModelsMixin,
@@ -217,7 +217,7 @@ class PlotShiftedVariables1d(
     SelectorStepsMixin,
     CalibratorsMixin,
     CategoriesMixin,
-    PlotBase1d,
+    PlotBase1D,
     ProcessPlotSettingMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
@@ -370,9 +370,9 @@ class PlotShiftedVariables1d(
                 outp.dump(fig, formatter="mpl")
 
 
-class PlotShiftedVariablesPerProcess1d(
+class PlotShiftedVariablesPerProcess1D(
     law.WrapperTask,
-    PlotShiftedVariables1d,
+    PlotShiftedVariables1D,
 ):
 
     # force this one to be a local workflow
@@ -380,6 +380,6 @@ class PlotShiftedVariablesPerProcess1d(
 
     def requires(self):
         return {
-            process: PlotShiftedVariables1d.req(self, processes=(process,))
+            process: PlotShiftedVariables1D.req(self, processes=(process,))
             for process in self.processes
         }

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -45,8 +45,8 @@ class PlotVariablesBase(
     def create_branch_map(self):
         return [
             DotDict({"category": cat_name, "variable": var_name})
-            for cat_name in sorted(self.categories)
-            for var_name in sorted(self.variables)
+            for var_name in self.variables
+            for cat_name in self.categories
         ]
 
     def workflow_requires(self, only_super: bool = False):
@@ -213,22 +213,21 @@ class PlotShiftedVariables1d(
         significant=True,
         description="when True, one plot per process is produced; default: False",
     )
-
     legend_title = luigi.Parameter(
         default=law.NO_STR,
         significant=False,
         description="sets the title of the legend; when empty and only one process is present in "
         "the plot, the process_inst label is used; empty default",
     )
-
-    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
-
     # overriding the default plot function
     plot_function_1d = luigi.Parameter(
         default="columnflow.plotting.example.plot_shifted_variable",
         significant=False,
         description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_shifted_variable'",
     )
+
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
+
     # default upstream dependency task classes
     dep_MergeShiftedHistograms = MergeShiftedHistograms
 
@@ -246,9 +245,9 @@ class PlotShiftedVariables1d(
     def create_branch_map(self):
         return [
             DotDict({"category": cat_name, "variable": var_name, "shift_source": source})
-            for cat_name in sorted(self.categories)
-            for var_name in sorted(self.variables)
-            for source in sorted(self.shift_sources)
+            for var_name in self.variables
+            for cat_name in self.categories
+            for source in self.shift_sources
         ]
 
     def workflow_requires(self, only_super: bool = False):

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -12,9 +12,11 @@ import luigi
 from columnflow.tasks.framework.base import ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
-    VariablesMixin, CategoriesMixin, ShiftSourcesMixin, EventWeightMixin,
+    CategoriesMixin, ShiftSourcesMixin, EventWeightMixin,
 )
-from columnflow.tasks.framework.plotting import PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin
+from columnflow.tasks.framework.plotting import (
+    PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
+)
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import DotDict, dev_sandbox, dict_add_strict
@@ -22,7 +24,7 @@ from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 
 class PlotVariablesBase(
     ShiftTask,
-    VariablesMixin,
+    VariablePlotSettingMixin,
     MLModelsMixin,
     ProducersMixin,
     SelectorStepsMixin,
@@ -210,7 +212,7 @@ class PlotVariablesPerProcess2D(
 
 
 class PlotShiftedVariables1D(
-    VariablesMixin,
+    VariablePlotSettingMixin,
     ShiftSourcesMixin,
     MLModelsMixin,
     ProducersMixin,


### PR DESCRIPTION
Changes in this PR:
- restructuring of plotting tasks
    - PlotVariables and PlotShiftedVariables tasks now inherit from the same base (PlotVariablesBase), using the same run method
    - PlotCutflow and PlotCutflowVariables also share a base (PlotCutflowBase)
    - reduction of the shift axis is now part of plotting functions for all tasks
- some `PerProcess` wrapper tasks are now included to produce 1 plot per process (for 2d plotting tasks and `PlotShiftedVariables`
- a `SettingsParameter` was implemented for the `process_settings` and the new `variable_settings` parameter
- `variable_settings` allows rebinding of individual variables and changing of the label associated to the variable
- plot functions now return the figure and all axes
- minor style changesChanges in this PR:
- restructuring of plotting tasks
    - PlotVariables and PlotShiftedVariables tasks now inherit from the same base (PlotVariablesBase), using the same run method
    - PlotCutflow and PlotCutflowVariables also share a base (PlotCutflowBase)
    - reduction of the shift axis is now part of plotting functions for all tasks
- some `PerProcess` wrapper tasks are now included to produce 1 plot per process (for 2d plotting tasks and `PlotShiftedVariables`
- a `SettingsParameter` was implemented for the `process_settings` and the new `variable_settings` parameter
- `variable_settings` allows rebinding of individual variables and changing of the label associated to the variable
- plot functions now return the figure and all axes
- minor style changes