### PR TITLE
Generalize plot function handling.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -335,7 +335,7 @@ class Route(object, metaclass=RouteMeta):
     def __add__(
         self,
         other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
-    ) -> "Route":
+    ) -> Route:
         route = self.copy()
         route.add(other)
         return route
@@ -343,13 +343,13 @@ class Route(object, metaclass=RouteMeta):
     def __radd__(
         self,
         other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
-    ) -> "Route":
+    ) -> Route:
         return self.__add__(other)
 
     def __iadd__(
         self,
         other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list | tuple],
-    ) -> "Route":
+    ) -> Route:
         self.add(other)
         return self
 

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -4,7 +4,6 @@
 Example 2d plot functions.
 """
 
-
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -219,10 +219,9 @@ class PlotCutflow(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
-    plot_function_1d = luigi.Parameter(
-        default="columnflow.plotting.example.plot_cutflow",
-        significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_cutflow'",
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.example.plot_cutflow",
+        amend_description=True,
     )
 
     def create_branch_map(self):
@@ -341,7 +340,7 @@ class PlotCutflow(
 
             # call the plot function
             fig, _ = self.call_plot_func(
-                self.plot_function_1d,
+                self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
                 **self.get_plot_parameters(),
@@ -365,8 +364,6 @@ class PlotCutflowVariablesBase(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
-    exclude_index = True
-
     only_final_step = luigi.BoolParameter(
         default=False,
         significant=False,
@@ -374,8 +371,9 @@ class PlotCutflowVariablesBase(
     )
 
     initial_step = "Initial"
-
     default_variables = ("cf_*",)
+
+    exclude_index = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -505,7 +503,10 @@ class PlotCutflowVariables1D(
     PlotBase1D,
     ProcessPlotSettingMixin,
 ):
-
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.example.plot_variable_per_process",
+        amend_description=True,
+    )
     per_plot = luigi.ChoiceParameter(
         choices=("processes", "steps"),
         default="processes",
@@ -593,6 +594,10 @@ class PlotCutflowVariables2D(
     PlotBase2D,
     ProcessPlotSettingMixin,
 ):
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.plot2d.plot_2d",
+        amend_description=True,
+    )
 
     def output(self):
         b = self.branch_data
@@ -616,7 +621,7 @@ class PlotCutflowVariables2D(
         for step in self.chosen_steps:
             # call the plot function
             fig, _ = self.call_plot_func(
-                self.plot_function_2d,
+                self.plot_function,
                 hists=hists[{"step": hist.loc(step)}],
                 config_inst=self.config_inst,
                 variable_insts=variable_insts,
@@ -633,7 +638,6 @@ class PlotCutflowVariablesPerProcess2D(
     law.WrapperTask,
     PlotCutflowVariables2D,
 ):
-
     # force this one to be a local workflow
     workflow = "local"
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -219,9 +219,9 @@ class PlotCutflow(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.example.plot_cutflow",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.example.plot_cutflow",
+        add_default_to_description=True,
     )
 
     def create_branch_map(self):
@@ -503,9 +503,9 @@ class PlotCutflowVariables1D(
     PlotBase1D,
     ProcessPlotSettingMixin,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.example.plot_variable_per_process",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.example.plot_variable_per_process",
+        add_default_to_description=True,
     )
     per_plot = luigi.ChoiceParameter(
         choices=("processes", "steps"),
@@ -594,9 +594,9 @@ class PlotCutflowVariables2D(
     PlotBase2D,
     ProcessPlotSettingMixin,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.plot2d.plot_2d",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        copy="columnflow.plotting.plot2d.plot_2d",
+        add_default_to_description=True,
     )
 
     def output(self):

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -6,33 +6,9 @@ Custom luigi parameters.
 
 from __future__ import annotations
 
-import copy
-
 import law
-import luigi
 
 from columnflow.util import test_float, DotDict
-
-
-class PlotFunctionParameter(luigi.Parameter):
-    """
-    Plain parameter subclass that provides a convenience method for copying an instance, assigning
-    a different default value and optionally changing the description text.
-    """
-
-    def with_default(
-        self,
-        default: str,
-        description: str | None = None,
-        amend_description: bool = False,
-    ) -> PlotFunctionParameter:
-        inst = copy.copy(self)
-        inst._default = default
-        if description is not None:
-            inst.description = description
-        elif amend_description:
-            inst.description += f"; default: {default}"
-        return inst
 
 
 class SettingsParameter(law.CSVParameter):

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -25,7 +25,7 @@ class PlotFunctionParameter(luigi.Parameter):
         default: str,
         description: str | None = None,
         amend_description: bool = False,
-    ) -> luigi.Parameter:
+    ) -> PlotFunctionParameter:
         inst = copy.copy(self)
         inst._default = default
         if description is not None:

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -4,11 +4,35 @@
 Custom luigi parameters.
 """
 
-from typing import Union
+from __future__ import annotations
+
+import copy
 
 import law
+import luigi
 
 from columnflow.util import test_float, DotDict
+
+
+class PlotFunctionParameter(luigi.Parameter):
+    """
+    Simply parameter subclass that provides a convenience method for copying an instance, assigning
+    a different default value and optionally changing the description text.
+    """
+
+    def with_default(
+        self,
+        default: str,
+        description: str | None = None,
+        amend_description: bool = False,
+    ) -> luigi.Parameter:
+        inst = copy.copy(self)
+        inst._default = default
+        if description is not None:
+            inst.description = description
+        elif amend_description:
+            inst.description += f"; default: {default}"
+        return inst
 
 
 class SettingsParameter(law.CSVParameter):
@@ -28,7 +52,7 @@ class SettingsParameter(law.CSVParameter):
     """
 
     @classmethod
-    def parse_setting(cls, setting: str) -> tuple[str, Union[float, bool, str]]:
+    def parse_setting(cls, setting: str) -> tuple[str, float | bool | str]:
         pair = setting.split("=", 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
         if test_float(value):

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -16,7 +16,7 @@ from columnflow.util import test_float, DotDict
 
 class PlotFunctionParameter(luigi.Parameter):
     """
-    Simply parameter subclass that provides a convenience method for copying an instance, assigning
+    Plain parameter subclass that provides a convenience method for copying an instance, assigning
     a different default value and optionally changing the description text.
     """
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -10,9 +10,11 @@ from typing import Any, Callable
 import law
 import luigi
 
-from columnflow.tasks.framework.parameters import SettingsParameter, MultiSettingsParameter
 from columnflow.tasks.framework.base import ConfigTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin, VariablesMixin
+from columnflow.tasks.framework.parameters import (
+    SettingsParameter, MultiSettingsParameter, PlotFunctionParameter,
+)
 from columnflow.util import DotDict, dict_add_strict
 
 
@@ -21,6 +23,10 @@ class PlotBase(ConfigTask):
     Base class for all plotting tasks.
     """
 
+    plot_function = PlotFunctionParameter(
+        significant=False,
+        description="location of the plot function to use in the format 'module.function_name'",
+    )
     file_types = law.CSVParameter(
         default=("pdf",),
         significant=True,
@@ -56,7 +62,7 @@ class PlotBase(ConfigTask):
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
-        params = DotDict({})
+        params = DotDict()
         dict_add_strict(params, "skip_legend", self.skip_legend)
         dict_add_strict(params, "skip_cms", self.skip_cms)
         dict_add_strict(params, "general_settings", self.general_settings)
@@ -155,12 +161,6 @@ class PlotBase1D(PlotBase):
     Base class for plotting tasks creating 1-dimensional plots.
     """
 
-    plot_function_1d = luigi.Parameter(
-        default="columnflow.plotting.example.plot_variable_per_process",
-        significant=False,
-        description="name of the 1d plot function; default: "
-        "columnflow.plotting.example.plot_variable_per_process",
-    )
     skip_ratio = law.OptionalBoolParameter(
         default=None,
         significant=False,
@@ -195,11 +195,6 @@ class PlotBase2D(PlotBase):
     Base class for plotting tasks creating 2-dimensional plots.
     """
 
-    plot_function_2d = luigi.Parameter(
-        default="columnflow.plotting.plot2d.plot_2d",
-        significant=False,
-        description="name of the 2d plot function; default: columnflow.plotting.plot2d.plot_2d",
-    )
     zscale = luigi.ChoiceParameter(
         choices=(law.NO_STR, "linear", "log"),
         default=law.NO_STR,

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -12,9 +12,7 @@ import luigi
 
 from columnflow.tasks.framework.base import ConfigTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin, VariablesMixin
-from columnflow.tasks.framework.parameters import (
-    SettingsParameter, MultiSettingsParameter, PlotFunctionParameter,
-)
+from columnflow.tasks.framework.parameters import SettingsParameter, MultiSettingsParameter
 from columnflow.util import DotDict, dict_add_strict
 
 
@@ -23,7 +21,7 @@ class PlotBase(ConfigTask):
     Base class for all plotting tasks.
     """
 
-    plot_function = PlotFunctionParameter(
+    plot_function = luigi.Parameter(
         significant=False,
         description="location of the plot function to use in the format 'module.function_name'",
     )

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -209,9 +209,9 @@ class PlotVariables1D(
     PlotVariablesBaseSingleShift,
     PlotBase1D,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.example.plot_variable_per_process",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.example.plot_variable_per_process",
+        add_default_to_description=True,
     )
 
 
@@ -219,9 +219,9 @@ class PlotVariables2D(
     PlotVariablesBaseSingleShift,
     PlotBase2D,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.plot2d.plot_2d",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.plot2d.plot_2d",
+        add_default_to_description=True,
     )
 
 
@@ -301,9 +301,9 @@ class PlotShiftedVariables1D(
     PlotVariablesBaseMultiShifts,
     PlotBase1D,
 ):
-    plot_function = PlotBase.plot_function.with_default(
-        "columnflow.plotting.example.plot_shifted_variable",
-        amend_description=True,
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.example.plot_shifted_variable",
+        add_default_to_description=True,
     )
 
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -152,20 +152,9 @@ class PlotVariablesBase(
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
-            # determine the correct plot function for this variable
-            plot_function = (
-                self.plot_function_1d if len(variable_insts) == 1 and "plot_function_1d" in dir(self) else
-                self.plot_function_2d if len(variable_insts) == 2 and "plot_function_2d" in dir(self) else
-                None
-            )
-            if not plot_function:
-                raise NotImplementedError(
-                    f"No Plotting function for {len(variable_insts)} variables implemented of task {self.task_family}",
-                )
-
             # call the plot function
             fig, _ = self.call_plot_func(
-                plot_function,
+                self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
                 variable_insts=variable_insts,
@@ -220,14 +209,20 @@ class PlotVariables1D(
     PlotVariablesBaseSingleShift,
     PlotBase1D,
 ):
-    pass
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.example.plot_variable_per_process",
+        amend_description=True,
+    )
 
 
 class PlotVariables2D(
     PlotVariablesBaseSingleShift,
     PlotBase2D,
 ):
-    pass
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.plot2d.plot_2d",
+        amend_description=True,
+    )
 
 
 class PlotVariablesPerProcess2D(
@@ -253,11 +248,6 @@ class PlotVariablesBaseMultiShifts(
         significant=False,
         description="sets the title of the legend; when empty and only one process is present in "
         "the plot, the process_inst label is used; empty default",
-    )
-    plot_function_1d = luigi.Parameter(
-        default="columnflow.plotting.example.plot_shifted_variable",
-        significant=False,
-        description="name of the 1d plot function; default: 'columnflow.plotting.example.plot_shifted_variable'",
     )
 
     # default upstream dependency task classes
@@ -311,7 +301,10 @@ class PlotShiftedVariables1D(
     PlotVariablesBaseMultiShifts,
     PlotBase1D,
 ):
-    pass
+    plot_function = PlotBase.plot_function.with_default(
+        "columnflow.plotting.example.plot_shifted_variable",
+        amend_description=True,
+    )
 
 
 class PlotShiftedVariablesPerProcess1D(


### PR DESCRIPTION
This PR generalizes the use of the `--plot-function` parameter. So far, there have been `*_1d` and `*_2d` versions of the same parameter and there was a switch in the generic PlotVariablesBase task that acted somewhat hardcoded, depending on the number of variables passed:

https://github.com/uhh-cms/columnflow/blob/43db794483e2529e3858d6a45ef662220a3b72d5/columnflow/tasks/plotting.py#L155-L158

If I understand correctly, this was intended for situations where both 1D and 2D variables were plotted at the same time. However, now that we have dedicated `PlotVariables{1,2}D` tasks (and for cutflows plots alike), this is no longer required. Therefore, it seems like merging the parameters into a single `--plot-function` parameter is a logical step forward (but correct me if I'm wrong @mafrahm).

Closes #122.