### PR TITLE
Check for non-finite numbers before writing.

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -108,6 +108,10 @@ class CalibrateEvents(
             # remove columns
             events = route_filter(events)
 
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(events)
+
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{lfn_index}_{pos.index}.parquet", type="f")
             output_chunks[(lfn_index, pos.index)] = chunk

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -123,6 +123,14 @@ class CalibrateEvents(
             law.pyarrow.merge_parquet_task(self, sorted_chunks, outp, local=True)
 
 
+# overwrite class defaults
+check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
+CalibrateEvents.check_finite = ChunkedReaderMixin.check_finite.copy(
+    default=CalibrateEvents.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+
 CalibrateEventsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
     require_cls=CalibrateEvents,

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -6,7 +6,6 @@ Lightweight mixins task classes.
 
 from __future__ import annotations
 
-import os
 import time
 import itertools
 from typing import Sequence, Any
@@ -21,6 +20,9 @@ from columnflow.selection import Selector
 from columnflow.production import Producer
 from columnflow.ml import MLModel
 from columnflow.inference import InferenceModel
+from columnflow.util import maybe_import
+
+ak = maybe_import("awkward")
 
 
 class CalibratorMixin(ConfigTask):
@@ -867,16 +869,13 @@ class EventWeightMixin(ConfigTask):
         return allowed_shifts
 
 
-_default_check_finite = law.util.flag_to_bool(os.getenv("CF_CHECK_FINITE_BEFORE_WRITING", "0"))
-
-
 class ChunkedReaderMixin(AnalysisTask):
 
     check_finite = luigi.BoolParameter(
-        default=_default_check_finite,
+        default=False,
         significant=False,
         description="when True, checks whether output arrays only contain finite values before "
-        f"writing to them to file; default: {_default_check_finite}",
+        "writing to them to file",
     )
 
     def iter_chunked_reader(self, *args, **kwargs):
@@ -914,14 +913,14 @@ class ChunkedReaderMixin(AnalysisTask):
                 self.chunked_reader = None
 
     @classmethod
-    def raise_if_not_finite(cls, obj: Any) -> None:
+    def raise_if_not_finite(cls, ak_array: ak.Array) -> None:
         import numpy as np
         import awkward as ak
         from columnflow.columnar_util import get_ak_routes
 
-        for route in get_ak_routes(obj):
-            if not ak.all(np.isfinite(ak.flatten(route.apply(obj), axis=None))):
+        for route in get_ak_routes(ak_array):
+            if ak.any(~np.isfinite(ak.flatten(route.apply(ak_array), axis=None))):
                 raise ValueError(
                     f"found one or more non-finite values in column '{route.column}' "
-                    f"of object {obj}",
+                    f"of array {ak_array}",
                 )

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -163,6 +163,14 @@ class PrepareMLEvents(
             self.publish_message(f"partition {' ' if f < 10 else ''}{f}: {n} ({r:.2f}%)")
 
 
+# overwrite class defaults
+check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
+PrepareMLEvents.check_finite = ChunkedReaderMixin.check_finite.copy(
+    default=PrepareMLEvents.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+
 PrepareMLEventsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
     require_cls=PrepareMLEvents,
@@ -443,6 +451,13 @@ class MLEvaluation(
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+
+
+# overwrite class defaults
+MLEvaluation.check_finite = ChunkedReaderMixin.check_finite.copy(
+    default=MLEvaluation.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
 
 
 MLEvaluationWrapper = wrapper_factory(

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -137,6 +137,10 @@ class PrepareMLEvents(
             # remove columns
             events = route_filter(events)
 
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(events)
+
             # loop over folds, use indices to generate masks and project into files
             for f in range(self.ml_model_inst.folds):
                 fold_events = events[fold_indices == f]
@@ -426,6 +430,10 @@ class MLEvaluation(
 
             # remove columns
             events = route_filter(events)
+
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(events)
 
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -114,6 +114,14 @@ class ProduceColumns(
         law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
 
 
+# overwrite class defaults
+check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
+ProduceColumns.check_finite = ChunkedReaderMixin.check_finite.copy(
+    default=ProduceColumns.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+
 ProduceColumnsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
     require_cls=ProduceColumns,

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -100,6 +100,10 @@ class ProduceColumns(
             # remove columns
             events = route_filter(events)
 
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(events)
+
             # save as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
             output_chunks[pos.index] = chunk

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -192,6 +192,14 @@ class SelectEvents(
         self.publish_message(f"efficiency         : {eff_weighted:.4f}")
 
 
+# overwrite class defaults
+check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
+SelectEvents.check_finite = ChunkedReaderMixin.check_finite.copy(
+    default=SelectEvents.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+
 SelectEventsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
     require_cls=SelectEvents,

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -145,15 +145,24 @@ class SelectEvents(
 
             # invoke the selection function
             events, results = self.selector_inst(events, stats)
+            results_array = results.to_ak()
+
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(results_array)
 
             # save results as parquet via a thread in the same pool
             chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")
             result_chunks[(lfn_index, pos.index)] = chunk
-            self.chunked_reader.queue(sorted_ak_to_parquet, (results.to_ak(), chunk.path))
+            self.chunked_reader.queue(sorted_ak_to_parquet, (results_array, chunk.path))
 
             # remove columns
             if keep_columns:
                 events = route_filter(events)
+
+                # optional check for finite values
+                if self.check_finite:
+                    self.raise_if_not_finite(events)
 
                 # save additional columns as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"cols_{lfn_index}_{pos.index}.parquet", type="f")

--- a/law.cfg
+++ b/law.cfg
@@ -28,6 +28,11 @@ inference_modules: columnflow.inference.example
 # wether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
 skip_ensure_proxy: False
 
+# csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
+# checked for non-finite values before saving them to disk (right now, supported tasks are
+# cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation)
+check_finite_output: None
+
 
 [outputs]
 


### PR DESCRIPTION
This PR adds checks to a couple places to identify non-finite (nan / inf) values before writing them to disk and having to deal with numeric problems (way) downstream.

The checks are done in all places where we currently write custom columns, i.e. in

- CalibrateEvents
- SelectEvents
- ProduceColumns
- PrepareMLEvents
- MLEvaluation

with the implementation being shared through the `ChunkedReaderMixin` (since all tasks that write columns do this through the reader object ... which we should rename at some point to reflect this).

Closes #119.