### PR TITLE
Rename chunked reader

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,16 @@ Backend for vectorized, columnar HEP analyses with pure Python, `law <https://gi
 .. marker-after-header
 
 
+Note on current development
+---------------------------
+
+This project is currently in a beta phase.
+The project setup, suggested workflows, definitions of particular tasks, and the signatures of various helper classes and functions are mostly frozen but could still be subject to changes in the near future.
+At this point (December 2022), four large-scale analyses based upon columnflow are being developed, and in the process, help test and verify various aspects of its core.
+The first released version is expected in early 2023.
+However, if you would like to join early on, contribute or just give it a spin, feel free to get in touch!
+
+
 Quickstart
 ----------
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -13,7 +13,7 @@ import law
 
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, ShiftTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedReaderMixin,
+    CalibratorsMixin, SelectorStepsMixin, VariablesMixin, CategoriesMixin, ChunkedIOMixin,
 )
 from columnflow.tasks.framework.plotting import (
     PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
@@ -29,7 +29,7 @@ class CreateCutflowHistograms(
     VariablesMixin,
     SelectorStepsMixin,
     CalibratorsMixin,
-    ChunkedReaderMixin,
+    ChunkedIOMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -120,7 +120,7 @@ class CreateCutflowHistograms(
                 # enable weights and store it
                 histograms[var_key] = h.Weight()
 
-        for arr, pos in self.iter_chunked_reader(
+        for arr, pos in self.iter_chunked_io(
             inputs["masks"].path,
             source_type="awkward_parquet",
         ):

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -36,7 +36,7 @@ class OutputLocation(enum.Enum):
 
 class BaseTask(law.Task):
 
-    task_namespace = os.getenv("CF_TASK_NAMESPACE")
+    task_namespace = law.config.get_expanded("analysis", "cf_task_namespace", "cf")
 
 
 class AnalysisTask(BaseTask, law.SandboxTask):

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -322,7 +322,6 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         "CF_STORE_LOCAL": "cf_store_local",
         "CF_LOCAL_SCHEDULER": "cf_local_scheduler",
         "CF_VOMS": "cf_voms",
-        "CF_TASK_NAMESPACE": "cf_task_namespace",
     }
 
     # default upstream dependency task classes

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -15,12 +15,6 @@ from columnflow.tasks.framework.base import AnalysisTask
 from columnflow.util import real_path
 
 
-_default_htcondor_flavor = os.getenv("CF_HTCONDOR_FLAVOR", "naf")
-_default_htcondor_share_software = law.util.flag_to_bool(os.getenv("CF_HTCONDOR_SHARE_SOFTWARE", "0"))
-_default_slurm_flavor = os.getenv("CF_SLURM_FLAVOR", "maxwell")
-_default_slurm_partition = os.getenv("CF_SLURM_PARTITION", "cms-uhh")
-
-
 class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLocalFile):
 
     replicas = luigi.IntParameter(
@@ -269,6 +263,10 @@ class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLo
         self.transfer(bundle)
 
 
+_default_htcondor_flavor = law.config.get_expanded("analysis", "htcondor_flavor", "cern")
+_default_htcondor_share_software = law.config.get_expanded_boolean("analysis", "htcondor_share_software", False)
+
+
 class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
 
     transfer_logs = luigi.BoolParameter(
@@ -310,7 +308,8 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
     )
 
     exclude_params_branch = {
-        "max_runtime", "htcondor_cpus", "htcondor_flavor", "htcondor_share_software",
+        "max_runtime", "htcondor_cpus", "htcondor_gpus", "htcondor_flavor",
+        "htcondor_share_software",
     }
 
     # mapping of environment variables to render variables that are forwarded
@@ -486,6 +485,10 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
     def htcondor_use_local_scheduler(self):
         # remote jobs should not communicate with ther central scheduler but with a local one
         return True
+
+
+_default_slurm_flavor = law.config.get_expanded("analysis", "slurm_flavor", "maxwell")
+_default_slurm_partition = law.config.get_expanded("analysis", "slurm_partition", "cms-uhh")
 
 
 class SlurmWorkflow(law.slurm.SlurmWorkflow):

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -18,7 +18,6 @@ bootstrap_htcondor_standalone() {
     export CF_LOCAL_SCHEDULER="{{cf_local_scheduler}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
     export CF_VOMS="{{cf_voms}}"
-    export CF_TASK_NAMESPACE="{{cf_task_namespace}}"
     export X509_USER_PROXY="${PWD}/{{voms_proxy_file}}"
 
     # fallback to a default path when the externally given software base is empty or inaccessible

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -12,7 +12,7 @@ import law
 from columnflow.tasks.framework.base import AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, VariablesMixin,
-    ShiftSourcesMixin, EventWeightMixin, ChunkedReaderMixin,
+    ShiftSourcesMixin, EventWeightMixin, ChunkedIOMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
@@ -29,7 +29,7 @@ class CreateHistograms(
     SelectorStepsMixin,
     CalibratorsMixin,
     EventWeightMixin,
-    ChunkedReaderMixin,
+    ChunkedIOMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -115,7 +115,7 @@ class CreateHistograms(
             files.extend([inp.path for inp in inputs["producers"]])
         if self.ml_models:
             files.extend([inp.path for inp in inputs["ml"]])
-        for (events, *columns), pos in self.iter_chunked_reader(
+        for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],
             # TODO: not working yet since parquet columns are nested

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -53,12 +53,18 @@ class ReduceEvents(
             return reqs
 
         reqs["lfns"] = self.dep_GetDatasetLFNs.req(self)
+
         if not self.pilot:
             reqs["calibrations"] = [
                 self.dep_CalibrateEvents.req(self, calibrator=c)
                 for c in self.calibrators
             ]
             reqs["selection"] = self.dep_SelectEvents.req(self)
+        else:
+            # pass-through pilot workflow requirements of upstream task
+            t = self.dep_SelectEvents.req(self)
+            reqs = law.util.merge_dicts(reqs, t.workflow_requires(), inplace=True)
+
         return reqs
 
     def requires(self):

--- a/law.cfg
+++ b/law.cfg
@@ -25,8 +25,22 @@ selection_modules: columnflow.selection.example
 ml_modules: columnflow.ml.example
 inference_modules: columnflow.inference.example
 
+# namespace of all columnflow tasks
+cf_task_namespace: cf
+
 # wether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
 skip_ensure_proxy: False
+
+# some remote workflow parameter defaults
+htcondor_flavor: $CF_HTCONDOR_FLAVOR
+htcondor_share_software: False
+slurm_flavor: $CF_SLURM_FLAVOR
+slurm_partition: $CF_SLURM_PARTITION
+
+# ChunkedIOHandler defaults
+chunked_io_chunk_size: 50000
+chunked_io_pool_size: 4
+chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
 # checked for non-finite values before saving them to disk (right now, supported tasks are
@@ -115,10 +129,10 @@ cache_mtime_patience: -1
 
 [luigi_core]
 
-local-scheduler: $CF_LOCAL_SCHEDULER
-default-scheduler-host: $CF_SCHEDULER_HOST
-default-scheduler-port: $CF_SCHEDULER_PORT
-parallel-scheduling: False
+local_scheduler: $CF_LOCAL_SCHEDULER
+scheduler_host: $CF_SCHEDULER_HOST
+scheduler_port: $CF_SCHEDULER_PORT
+parallel_scheduling: False
 no_lock: True
 log_level: INFO
 
@@ -126,9 +140,9 @@ log_level: INFO
 [luigi_scheduler]
 
 record_task_history: False
-remove-delay: 86400
-retry-delay: 30
-worker-disconnect-delay: 30
+remove_delay: 86400
+retry_delay: 30
+worker_disconnect_delay: 30
 
 
 [luigi_worker]

--- a/setup.sh
+++ b/setup.sh
@@ -92,8 +92,6 @@ setup_columnflow() {
     #   CF_CERN_USER_FIRSTCHAR
     #       The first character of the user's CERN / WLCG name. Derived from $CF_CERN_USER. Used in
     #       law.cfg.
-    #   CF_TASK_NAMESPACE
-    #       The prefix (namespace) of tasks in columnflow. Set to "cf" when not already defined.
     #   CF_LOCAL_SCHEDULER
     #       Either "true" or "false", deciding whether the process-local luigi scheduler should be
     #       used by default. Queried during the interactive setup. Used in law.cfg.

--- a/setup.sh
+++ b/setup.sh
@@ -156,14 +156,6 @@ setup_columnflow() {
     # (CF = columnflow)
     #
 
-    # lang defaults
-    export LANGUAGE="${LANGUAGE:-en_US.UTF-8}"
-    export LANG="${LANG:-en_US.UTF-8}"
-    export LC_ALL="${LC_ALL:-en_US.UTF-8}"
-
-    # proxy
-    export X509_USER_PROXY="${X509_USER_PROXY:-/tmp/x509up_u$( id -u )}"
-
     # start exporting variables
     export CF_BASE="${this_dir}"
     export CF_SETUP_NAME="${setup_name}"
@@ -183,7 +175,6 @@ setup_columnflow() {
             query CF_SOFTWARE_BASE "Local directory for installing software" "\$CF_DATA/software"
             query CF_JOB_BASE "Local directory for storing job files" "\$CF_DATA/jobs"
             query CF_VOMS "Virtual-organization" "cms"
-            export_and_save CF_TASK_NAMESPACE "${CF_TASK_NAMESPACE:-cf}"
             query CF_LOCAL_SCHEDULER "Use a local scheduler for law tasks" "True"
             if [ "${CF_LOCAL_SCHEDULER}" != "True" ]; then
                 query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "127.0.0.1"
@@ -207,20 +198,6 @@ setup_columnflow() {
     export CF_ORIG_PYTHON3PATH="${PYTHON3PATH}"
     export CF_ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 
-    # overwrite some variables in remote and ci jobs
-    if [ "${CF_REMOTE_JOB}" = "1" ]; then
-        export CF_WLCG_USE_CACHE="true"
-        export CF_WLCG_CACHE_CLEANUP="true"
-        export CF_WORKER_KEEP_ALIVE="false"
-    elif [ "${CF_CI_JOB}" = "1" ]; then
-        export CF_WORKER_KEEP_ALIVE="false"
-    fi
-
-    # some variable defaults
-    export CF_WORKER_KEEP_ALIVE="${CF_WORKER_KEEP_ALIVE:-false}"
-    export CF_SCHEDULER_HOST="${CF_SCHEDULER_HOST:-127.0.0.1}"
-    export CF_SCHEDULER_PORT="${CF_SCHEDULER_PORT:-8082}"
-
 
     #
     # minimal local software setup
@@ -230,24 +207,10 @@ setup_columnflow() {
 
 
     #
-    # detect host-dependent variables
+    # common variables
     #
 
-    # default job flavor settings, used by tasks/framework/remote.py
-    local hname="$( hostname 2> /dev/null )"
-    if [ "$?" = "0" ]; then
-        # start with naf / maxwell cluster defaults
-        local cf_htcondor_flavor_default="naf"
-        local cf_slurm_flavor_default="maxwell"
-        local cf_slurm_partition_default="cms-uhh"
-        # lxplus
-        if [[ "${hname}" == lx*.cern.ch ]]; then
-            cf_htcondor_flavor_default="cern"
-        fi
-        export CF_HTCONDOR_FLAVOR="${CF_HTCONDOR_FLAVOR:-${cf_htcondor_flavor_default}}"
-        export CF_SLURM_FLAVOR="${CF_SLURM_FLAVOR:-${cf_slurm_flavor_default}}"
-        export CF_SLURM_PARTITION="${CF_SLURM_PARTITION:-${cf_slurm_partition_default}}"
-    fi
+    cf_setup_common_variables || return "$?"
 
 
     #
@@ -267,6 +230,49 @@ setup_columnflow() {
 
     # finalize
     export CF_SETUP="1"
+}
+
+cf_setup_common_variables() {
+    # Exports variables that might be commonly used across analyses, such as host and job
+    # environment variables (or their defaults).
+
+    # lang defaults
+    export LANGUAGE="${LANGUAGE:-en_US.UTF-8}"
+    export LANG="${LANG:-en_US.UTF-8}"
+    export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+    # proxy
+    export X509_USER_PROXY="${X509_USER_PROXY:-/tmp/x509up_u$( id -u )}"
+
+    # overwrite some variables in remote and ci jobs
+    if [ "${CF_REMOTE_JOB}" = "1" ]; then
+        export CF_WLCG_USE_CACHE="true"
+        export CF_WLCG_CACHE_CLEANUP="true"
+        export CF_WORKER_KEEP_ALIVE="false"
+    elif [ "${CF_CI_JOB}" = "1" ]; then
+        export CF_WORKER_KEEP_ALIVE="false"
+    fi
+
+    # luigi worker and scheduler defaults (assigned in law.cfg)
+    export CF_WORKER_KEEP_ALIVE="${CF_WORKER_KEEP_ALIVE:-false}"
+    export CF_SCHEDULER_HOST="${CF_SCHEDULER_HOST:-127.0.0.1}"
+    export CF_SCHEDULER_PORT="${CF_SCHEDULER_PORT:-8082}"
+
+    # default job flavor settings (starting with naf / maxwell cluster defaults)
+    # used by law.cfg and, in turn, tasks/framework/remote.py
+    local cf_htcondor_flavor_default="naf"
+    local cf_slurm_flavor_default="maxwell"
+    local cf_slurm_partition_default="cms-uhh"
+    local hname="$( hostname 2> /dev/null )"
+    if [ "$?" = "0" ]; then
+        # lxplus
+        if [[ "${hname}" == lx*.cern.ch ]]; then
+            cf_htcondor_flavor_default="cern"
+        fi
+    fi
+    export CF_HTCONDOR_FLAVOR="${CF_HTCONDOR_FLAVOR:-${cf_htcondor_flavor_default}}"
+    export CF_SLURM_FLAVOR="${CF_SLURM_FLAVOR:-${cf_slurm_flavor_default}}"
+    export CF_SLURM_PARTITION="${CF_SLURM_PARTITION:-${cf_slurm_partition_default}}"
 }
 
 cf_setup_interactive() {


### PR DESCRIPTION
This PR mainly updates the `ChunkedReader` in `columnar_util.py` to `ChunkedIOHandler` since it also handles file writing. Accordingly, `ChunkedReaderMixin` is renamed to `ChunkedIOMixin` with its main method renamed to `iter_chunked_io`. This change had to be propagated to all tasks making use of that method.

*In addition*, there are two minor changes included:

- I added a `Note on current development` to communicate that the project is still undergoing some structural changes here and there.
- I noticed that some environment variables are required throughout columnflow, but every deriving analysis has to set them on their own. This can introduce situations where a change of the expected values could require N analysis to slightly change their setup which is far from ideal. There is a new setup function now that particular analyses can call during their own `setup.sh` to end up with the variables that columnflow needs.

@jolange @dsavoiu @mafrahm I don't think this requires too deep of a review, but I added you here since changes to your analysis might be required. I'll open PRs in your repos though.