### PR TITLE
Add CoalesceColumns task.

### DIFF
--- a/columnflow/tasks/coalesce.py
+++ b/columnflow/tasks/coalesce.py
@@ -83,7 +83,7 @@ class CoalesceColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return self.target(f"columns__{self.branch}.parquet")
+        return self.target(f"data_{self.branch}.parquet")
 
     @law.decorator.log
     @law.decorator.localize(input=True, output=False)

--- a/columnflow/tasks/coalesce.py
+++ b/columnflow/tasks/coalesce.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+
+"""
+Task to merge columns into a single file for further processing.
+"""
+
+import law
+
+from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, ChunkedIOMixin,
+)
+from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
+from columnflow.tasks.production import ProduceColumns
+from columnflow.tasks.ml import MLEvaluation
+from columnflow.util import dev_sandbox
+
+
+class CoalesceColumns(
+    MergeReducedEventsUser,
+    MLModelsMixin,
+    ProducersMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    ChunkedIOMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
+
+    # default upstream dependency task classes
+    dep_MergeReducedEvents = MergeReducedEvents
+    dep_ProduceColumns = ProduceColumns
+    dep_MLEvaluation = MLEvaluation
+
+    @classmethod
+    def get_allowed_shifts(cls, config_inst, params):
+        shifts = super().get_allowed_shifts(config_inst, params)
+        shifts |= cls.dep_MergeReducedEvents.get_allowed_shifts(config_inst, params)
+        shifts |= cls.dep_ProduceColumns.get_allowed_shifts(config_inst, params)
+        return shifts
+
+    def workflow_requires(self, only_super: bool = False):
+        reqs = super().workflow_requires()
+        if only_super:
+            return reqs
+
+        # require the full merge forest
+        reqs["events"] = self.dep_MergeReducedEvents.req(self, tree_index=-1)
+
+        if not self.pilot:
+            if self.producers:
+                reqs["producers"] = [
+                    self.dep_ProduceColumns.req(self, producer=p)
+                    for p in self.producers
+                ]
+            if self.ml_models:
+                reqs["ml"] = [
+                    self.dep_MLEvaluation.req(self, ml_model=m)
+                    for m in self.ml_models
+                ]
+
+        return reqs
+
+    def requires(self):
+        reqs = {
+            "events": self.dep_MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+        }
+
+        if self.producers:
+            reqs["producers"] = [
+                self.dep_ProduceColumns.req(self, producer=p)
+                for p in self.producers
+            ]
+        if self.ml_models:
+            reqs["ml"] = [
+                self.dep_MLEvaluation.req(self, ml_model=m)
+                for m in self.ml_models
+            ]
+
+        return reqs
+
+    @MergeReducedEventsUser.maybe_dummy
+    def output(self):
+        return self.target(f"columns__{self.branch}.parquet")
+
+    @law.decorator.log
+    @law.decorator.localize(input=True, output=False)
+    @law.decorator.safe_output
+    def run(self):
+        from columnflow.columnar_util import RouteFilter, update_ak_array, sorted_ak_to_parquet
+
+        # prepare inputs and outputs
+        inputs = self.input()
+        output = self.output()
+        output_chunks = {}
+
+        # create a temp dir for saving intermediate files
+        tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
+        tmp_dir.touch()
+
+        # define nano columns that should be kept, and that need to be loaded
+        keep_columns = set(self.config_inst.x.keep_columns[self.task_family])
+        # load_columns = keep_columns | set(mandatory_coffea_columns)
+        route_filter = RouteFilter(keep_columns)
+
+        # iterate over chunks of events and diffs
+        files = [inputs["events"]["collection"][0].path]
+        if self.producers:
+            files.extend([inp.path for inp in inputs["producers"]])
+        if self.ml_models:
+            files.extend([inp.path for inp in inputs["ml"]])
+        for (events, *columns), pos in self.iter_chunked_io(
+            files,
+            source_type=len(files) * ["awkward_parquet"],
+            # TODO: not working yet since parquet columns are nested
+            # open_options=[{"columns": load_columns}] + (len(files) - 1) * [None],
+        ):
+            # add additional columns
+            events = update_ak_array(events, *columns)
+
+            # remove columns
+            events = route_filter(events)
+
+            # optional check for finite values
+            if self.check_finite:
+                self.raise_if_not_finite(events)
+
+            # save as parquet via a thread in the same pool
+            chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
+            output_chunks[pos.index] = chunk
+            self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+
+        # merge output files
+        sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
+        law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+
+
+# overwrite class defaults
+check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
+CoalesceColumns.check_finite = ChunkedIOMixin.check_finite.copy(
+    default=CoalesceColumns.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+
+CoalesceColumnsWrapper = wrapper_factory(
+    base_cls=AnalysisTask,
+    require_cls=CoalesceColumns,
+    enable=["configs", "skip_configs", "datasets", "skip_datasets", "shifts", "skip_shifts"],
+)

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -103,7 +103,7 @@ class ReduceEvents(
         aliases = self.shift_inst.x("column_aliases_selection_dependent", {})
 
         # define nano columns that should be kept, and that need to be loaded
-        keep_columns = set(self.config_inst.x.keep_columns[self.task_family])
+        keep_columns = set(self.config_inst.x.keep_columns.get(self.task_family, ["*"]))
         load_columns = keep_columns | set(mandatory_coffea_columns)
         load_columns_nano = [Route(column).nano_column for column in load_columns]
         route_filter = RouteFilter(keep_columns)

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Task to merge columns into a single file for further processing.
+Task to unite columns horizontally into a single file for further, possibly external processing.
 """
 
 import law
@@ -17,7 +17,7 @@ from columnflow.tasks.ml import MLEvaluation
 from columnflow.util import dev_sandbox
 
 
-class CoalesceColumns(
+class UniteColumns(
     MergeReducedEventsUser,
     MLModelsMixin,
     ProducersMixin,
@@ -101,7 +101,7 @@ class CoalesceColumns(
         tmp_dir.touch()
 
         # define nano columns that should be kept, and that need to be loaded
-        keep_columns = set(self.config_inst.x.keep_columns[self.task_family])
+        keep_columns = set(self.config_inst.x.keep_columns.get(self.task_family, ["*"]))
         # load_columns = keep_columns | set(mandatory_coffea_columns)
         route_filter = RouteFilter(keep_columns)
 
@@ -139,14 +139,14 @@ class CoalesceColumns(
 
 # overwrite class defaults
 check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
-CoalesceColumns.check_finite = ChunkedIOMixin.check_finite.copy(
-    default=CoalesceColumns.task_family in check_finite_tasks,
+UniteColumns.check_finite = ChunkedIOMixin.check_finite.copy(
+    default=UniteColumns.task_family in check_finite_tasks,
     add_default_to_description=True,
 )
 
 
-CoalesceColumnsWrapper = wrapper_factory(
+UniteColumnsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
-    require_cls=CoalesceColumns,
+    require_cls=UniteColumns,
     enable=["configs", "skip_configs", "datasets", "skip_datasets", "shifts", "skip_shifts"],
 )

--- a/law.cfg
+++ b/law.cfg
@@ -7,6 +7,7 @@ columnflow.tasks.selection
 columnflow.tasks.reduction
 columnflow.tasks.production
 columnflow.tasks.ml
+columnflow.tasks.coalesce
 columnflow.tasks.histograms
 columnflow.tasks.plotting
 columnflow.tasks.inference
@@ -44,7 +45,8 @@ chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
 # checked for non-finite values before saving them to disk (right now, supported tasks are
-# cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation)
+# cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation,
+# cf.CoalesceColumns)
 check_finite_output: None
 
 

--- a/law.cfg
+++ b/law.cfg
@@ -7,7 +7,7 @@ columnflow.tasks.selection
 columnflow.tasks.reduction
 columnflow.tasks.production
 columnflow.tasks.ml
-columnflow.tasks.coalesce
+columnflow.tasks.union
 columnflow.tasks.histograms
 columnflow.tasks.plotting
 columnflow.tasks.inference
@@ -46,7 +46,7 @@ chunked_io_debug: False
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
 # checked for non-finite values before saving them to disk (right now, supported tasks are
 # cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation,
-# cf.CoalesceColumns)
+# cf.UniteColumns)
 check_finite_output: None
 
 


### PR DESCRIPTION
This PR adds an additional task that horizontally unites / coalesces columns (unlike the `Merge*` tasks that work vertically) from

- MergeReducedEvents
- ProduceColumns
- MLEvaluation

to have a point in the workflow where we can save the state of columns used for creating histograms also into parquet files. Use cases are (e.g.)

- giving combined files to students
- passing events to other groups for synchronization purposes.

The implementation is straight forward and resembles that of other tasks.