### PR TITLE
Labels and Whitespace

### DIFF
--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -117,7 +117,7 @@ def plot_all(
     skip_ratio: bool = False,
     shape_norm: bool = False,
     skip_legend: bool = False,
-    skip_cms: bool = False,
+    cms_label: str = "wip",
     **kwargs,
 ) -> plt.Figure:
     """
@@ -205,17 +205,35 @@ def plot_all(
         legend_kwargs.update(style_config.get("legend_cfg", {}))
         ax.legend(**legend_kwargs)
 
-    # cms label
-    cms_label_kwargs = {
-        "ax": ax,
-        "llabel": "Work in progress",
+    # custom annotation
+    annotate_kwargs = {
+        "text": "",
+        "xy": (30, 540),  # this might be quite unstable, e.g. when `skip_cms`=True, the relative position changes
+        "xycoords": "axes points",
+        "color": "black",
         "fontsize": 22,
     }
-    # TODO: set "data": False when there are no data histograms (adds 'Simulation' to CMS label)
-    cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
-    if skip_cms:
-        cms_label_kwargs.update({"data": True, "label": ""})
-    mplhep.cms.label(**cms_label_kwargs)
+    annotate_kwargs.update(style_config.get("annotate_cfg", {}))
+    plt.annotate(**annotate_kwargs)
+
+    # cms label
+    if cms_label != "skip":
+        label_options = {
+            "wip": "Work in Progress",
+            "prelim": "Preliminary",
+            "public": "",
+        }
+        cms_label_kwargs = {
+            "ax": ax,
+            "llabel": label_options[cms_label],
+            "fontsize": 22,
+            "data": False,
+        }
+        if "data" not in plot_config.keys():
+            cms_label_kwargs["llabel"] = "Simulation" + cms_label_kwargs["llabel"]
+
+        cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
+        mplhep.cms.label(**cms_label_kwargs)
 
     plt.tight_layout()
 
@@ -225,6 +243,7 @@ def plot_all(
 def plot_variable_per_process(
     hists: OrderedDict,
     config_inst: od.config,
+    category_inst: od.category,
     variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool | None = False,
@@ -259,6 +278,7 @@ def plot_variable_per_process(
             "xlabel": variable_inst.get_full_x_title(),
         },
         "legend_cfg": {},
+        "annotate_cfg": {"text": category_inst.label},
         "cms_label_cfg": {
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
@@ -273,6 +293,7 @@ def plot_variable_per_process(
 def plot_variable_variants(
     hists: OrderedDict,
     config_inst: od.config,
+    category_inst: od.category,
     variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
@@ -323,6 +344,7 @@ def plot_variable_variants(
         "cms_label_cfg": {
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
+        "annotate_cfg": {"text": category_inst.label},
     }
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
     if shape_norm:
@@ -334,6 +356,7 @@ def plot_variable_variants(
 def plot_shifted_variable(
     hists: Sequence[hist.Hist],
     config_inst: od.config,
+    category_inst: od.category,
     variable_insts: list[od.variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
@@ -415,6 +438,7 @@ def plot_shifted_variable(
         "legend_cfg": {
             "title": legend_title,
         },
+        "annotate_cfg": {"text": category_inst.label},
         "cms_label_cfg": {
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },
@@ -429,6 +453,7 @@ def plot_shifted_variable(
 def plot_cutflow(
     hists: OrderedDict,
     config_inst: od.config,
+    category_inst: od.category,
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
@@ -479,6 +504,7 @@ def plot_cutflow(
         "legend_cfg": {
             "loc": "upper right",
         },
+        "annotate_cfg": {"text": category_inst.label},
         "cms_label_cfg": {
             "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
         },

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -208,7 +208,7 @@ def plot_all(
     # custom annotation
     annotate_kwargs = {
         "text": "",
-        "xy": (30, 540),  # this might be quite unstable, e.g. when `skip_cms`=True, the relative position changes
+        "xy": (30, 540),  # this might be quite unstable, e.g. when cms_label=skip, the relative position changes
         "xycoords": "axes points",
         "color": "black",
         "fontsize": 22,

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -1,4 +1,4 @@
-od# coding: utf-8
+# coding: utf-8
 
 """
 Example plot functions.

--- a/columnflow/plotting/example.py
+++ b/columnflow/plotting/example.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+od# coding: utf-8
 
 """
 Example plot functions.
@@ -230,7 +230,7 @@ def plot_all(
     # cms label
     if cms_label != "skip":
         label_options = {
-            "wip": "Work in Progress",
+            "wip": "Work in progress",
             "prelim": "Preliminary",
             "public": "",
         }
@@ -253,9 +253,9 @@ def plot_all(
 
 def plot_variable_per_process(
     hists: OrderedDict,
-    config_inst: od.config,
-    category_inst: od.category,
-    variable_insts: list[od.variable],
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
     style_config: dict | None = None,
     shape_norm: bool | None = False,
     yscale: str | None = "",
@@ -303,9 +303,9 @@ def plot_variable_per_process(
 
 def plot_variable_variants(
     hists: OrderedDict,
-    config_inst: od.config,
-    category_inst: od.category,
-    variable_insts: list[od.variable],
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
@@ -366,9 +366,9 @@ def plot_variable_variants(
 
 def plot_shifted_variable(
     hists: Sequence[hist.Hist],
-    config_inst: od.config,
-    category_inst: od.category,
-    variable_insts: list[od.variable],
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,
@@ -463,8 +463,8 @@ def plot_shifted_variable(
 
 def plot_cutflow(
     hists: OrderedDict,
-    config_inst: od.config,
-    category_inst: od.category,
+    config_inst: od.Config,
+    category_inst: od.Category,
     style_config: dict | None = None,
     shape_norm: bool = False,
     yscale: str | None = None,

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -12,7 +12,9 @@ import law
 
 from columnflow.util import maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT
-from columnflow.plotting.plot_util import remove_residual_axis, apply_variable_settings
+from columnflow.plotting.plot_util import (
+    remove_residual_axis, apply_variable_settings, get_position,
+)
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -76,10 +78,6 @@ def plot_2d(
         },
         "annotate_cfg": {
             "text": category_inst.label,
-            "xy": (30, 540),  # this might be quite unstable, e.g. when cms_label=skip
-            "xycoords": "axes points",
-            "color": "black",
-            "fontsize": 22,
         },
     }
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
@@ -103,7 +101,20 @@ def plot_2d(
         ax.legend(**style_config["legend_cfg"])
 
     # annotation of category label
-    plt.annotate(**default_style_config["annotate_cfg"])
+    annotate_kwargs = {
+        "text": "",
+        "xy": (
+            get_position(*ax.get_xlim(), factor=0.05, logscale=False),
+            get_position(*ax.get_ylim(), factor=0.95, logscale=False),
+        ),
+        "xycoords": "data",
+        "color": "black",
+        "fontsize": 22,
+        "horizontalalignment": "left",
+        "verticalalignment": "top",
+    }
+    annotate_kwargs.update(default_style_config.get("annotate_cfg", {}))
+    plt.annotate(**annotate_kwargs)
 
     # cms label
     if cms_label != "skip":

--- a/columnflow/plotting/plot2d.py
+++ b/columnflow/plotting/plot2d.py
@@ -26,9 +26,9 @@ od = maybe_import("order")
 
 def plot_2d(
     hists: OrderedDict,
-    config_inst: od.config,
-    category_inst: od.category,
-    variable_insts: list[od.variable],
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
     style_config: dict | None = None,
     shape_norm: bool | None = False,
     zscale: str | None = "",
@@ -119,7 +119,7 @@ def plot_2d(
     # cms label
     if cms_label != "skip":
         label_options = {
-            "wip": "Work in Progress",
+            "wip": "Work in progress",
             "prelim": "Preliminary",
             "public": "",
         }

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -167,8 +167,6 @@ def prepare_plot_config(
 
 def get_position(minimum: float, maximum: float, factor: float = 1.4, logscale: bool = False) -> float:
     """ get a relative position between a min and max value based on the scale """
-    import math
-
     if logscale:
         value = 10 ** ((math.log10(maximum) - math.log10(minimum)) * factor + math.log10(minimum))
     else:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 
 from columnflow.util import maybe_import
 
+math = maybe_import("math")
 hist = maybe_import("hist")
 np = maybe_import("numpy")
 plt = maybe_import("matplotlib.pyplot")

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -162,3 +162,15 @@ def prepare_plot_config(
         }
 
     return plot_config
+
+
+def get_position(minimum: float, maximum: float, factor: float = 1.4, logscale: bool = False) -> float:
+    """ get a relative position between a min and max value based on the scale """
+    import math
+
+    if logscale:
+        value = 10 ** ((math.log10(maximum) - math.log10(minimum)) * factor + math.log10(minimum))
+    else:
+        value = (maximum - minimum) * factor + minimum
+
+    return value

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -343,6 +343,7 @@ class PlotCutflow(
                 self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
+                category_inst=category_inst,
                 **self.get_plot_parameters(),
             )
 
@@ -494,6 +495,7 @@ class PlotCutflowVariablesBase(
             # call a postprocess function that produces outputs based on the implementation of the daughter task
             self.run_postprocess(
                 hists=hists,
+                category_inst=category_inst,
                 variable_insts=variable_insts,
             )
 
@@ -538,7 +540,7 @@ class PlotCutflowVariables1D(
                 for p in self.processes
             })
 
-    def run_postprocess(self, hists, variable_insts):
+    def run_postprocess(self, hists, category_inst, variable_insts):
         import hist
 
         if len(variable_insts) != 1:
@@ -558,6 +560,7 @@ class PlotCutflowVariables1D(
                     self.plot_function_per_process,
                     hists=step_hists,
                     config_inst=self.config_inst,
+                    category_inst=category_inst,
                     variable_insts=variable_insts,
                     style_config={"legend_cfg": {"title": f"Step '{step}'"}},
                     **self.get_plot_parameters(),
@@ -579,6 +582,7 @@ class PlotCutflowVariables1D(
                     self.plot_function_per_step,
                     hists=process_hists,
                     config_inst=self.config_inst,
+                    category_inst=category_inst,
                     variable_insts=variable_insts,
                     style_config={"legend_cfg": {"title": process_inst.label}},
                     **self.get_plot_parameters(),

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -52,17 +52,19 @@ class PlotBase(ConfigTask):
         significant=False,
         description="when True, no legend is drawn; default: None",
     )
-    skip_cms = law.OptionalBoolParameter(
-        default=None,
+    cms_label = luigi.ChoiceParameter(
+        choices=("wip", "prelim", "public", "skip"),
+        default="wip",
         significant=False,
-        description="when True, no CMS logo is drawn; default: None",
+        description="Parameter to set the type of CMS logo; choices: wip,prelim,public,skip; "
+        "default: wip",
     )
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = DotDict()
         dict_add_strict(params, "skip_legend", self.skip_legend)
-        dict_add_strict(params, "skip_cms", self.skip_cms)
+        dict_add_strict(params, "cms_label", self.cms_label)
         dict_add_strict(params, "general_settings", self.general_settings)
         return params
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -157,6 +157,7 @@ class PlotVariablesBase(
                 self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
+                category_inst=category_inst,
                 variable_insts=variable_insts,
                 **self.get_plot_parameters(),
             )


### PR DESCRIPTION
This PR contains:

- The `skip_cms` parameter is changed to a `cms_label` ChoiceParameter
- An annotation is added to plots, displaying the `category_inst.label`
- Adding whitespace to a plot is simplified with the `get_position` function

Closes #134 