### PR TITLE
Add hook to ml models for adding requirements.

### DIFF
--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -29,6 +29,7 @@ class MLModel(Derivable):
         - :py:meth:`datasets`
         - :py:meth:`uses`,
         - :py:meth:`produces`
+        - :py:meth:`requires`
         - :py:meth:`output`
         - :py:meth:`open_model`
         - :py:meth:`train`
@@ -167,6 +168,12 @@ class MLModel(Derivable):
         Returns a set of all produced columns. To be implemented in subclasses.
         """
         raise NotImplementedError()
+
+    def requires(self, task: law.Task) -> Any:
+        """
+        Returns required tasks that should be performed beforehand and whose outputs are needed.
+        """
+        return None
 
     def output(self, task: law.Task) -> Any:
         """

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -286,7 +286,10 @@ class MLTraining(MLModelMixin, ProducersMixin, SelectorMixin, CalibratorsMixin):
         return self.ml_model_inst.sandbox(self)
 
     def requires(self):
-        return {
+        reqs = []
+
+        # require prepared events
+        reqs["events"] = {
             dataset_inst.name: [
                 self.dep_MergeMLEvents.req(self, dataset=dataset_inst.name, fold=f)
                 for f in range(self.ml_model_inst.folds)
@@ -294,6 +297,11 @@ class MLTraining(MLModelMixin, ProducersMixin, SelectorMixin, CalibratorsMixin):
             ]
             for dataset_inst in self.ml_model_inst.used_datasets
         }
+
+        # ml model requirements
+        reqs["model"] = self.ml_model_inst.requires()
+
+        return reqs
 
     def output(self):
         return self.ml_model_inst.output(self)


### PR DESCRIPTION
This is rather small PR that allows ML models to define requirements that are picked up the the workflow, in order to obtain information from other tasks that might be needed during the training (e.g. selection stats, reduction stats, ...)