### PR TITLE
Fix systematic shift resolution

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -6,6 +6,7 @@ Object and event calibration tools.
 
 from __future__ import annotations
 
+import inspect
 from typing import Callable
 
 from columnflow.util import DerivableMeta
@@ -30,9 +31,13 @@ def calibrator(
         cls_dict = {"call_func": func}
         cls_dict.update(kwargs)
 
+        # get the module name
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+
         # create the subclass
         cls_name = cls_dict.pop("cls_name", func.__name__)
-        subclass = Calibrator.derive(cls_name, bases=bases, cls_dict=cls_dict)
+        subclass = Calibrator.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
 
         return subclass
 

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1760,23 +1760,24 @@ class TaskArrayFunction(ArrayFunction):
         return super().instantiate_dependency(cls, **kwargs)
 
     def _get_all_shifts(self, call_cache: set | None = None) -> set[str]:
-        shifts = set()
-
         # init the call cache
         if call_cache is None:
             call_cache = set()
 
-        # consider _this_ call cached
+        # add shifts and consider _this_ call cached
+        shifts = {
+            shift
+            for shift in self.shifts
+            if not isinstance(shift, (ArrayFunction, self.Flagged))
+        }
         call_cache.add(self)
 
         # add shifts of all dependent objects
-        for obj in self.get_dependencies(include_others=True):
+        for obj in self.get_dependencies(include_others=False):
             if isinstance(obj, TaskArrayFunction):
                 if obj not in call_cache:
                     call_cache.add(obj)
                     shifts |= obj._get_all_shifts(call_cache=call_cache)
-            elif isinstance(obj, str):
-                shifts.add(obj)
 
         return shifts
 

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -6,6 +6,7 @@ Tools for producing new array columns (e.g. high-level variables).
 
 from __future__ import annotations
 
+import inspect
 from typing import Callable
 
 from columnflow.util import DerivableMeta
@@ -30,9 +31,13 @@ def producer(
         cls_dict = {"call_func": func}
         cls_dict.update(kwargs)
 
+        # get the module name
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+
         # create the subclass
         cls_name = cls_dict.pop("cls_name", func.__name__)
-        subclass = Producer.derive(cls_name, bases=bases, cls_dict=cls_dict)
+        subclass = Producer.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
 
         return subclass
 

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -6,6 +6,7 @@ Object and event selection tools.
 
 from __future__ import annotations
 
+import inspect
 from typing import Callable
 
 import law
@@ -46,9 +47,13 @@ def selector(
         cls_dict = {"call_func": func}
         cls_dict.update(kwargs)
 
+        # get the module name
+        frame = inspect.stack()[1]
+        module = inspect.getmodule(frame[0])
+
         # create the subclass
         cls_name = cls_dict.pop("cls_name", func.__name__)
-        subclass = Selector.derive(cls_name, bases=bases, cls_dict=cls_dict)
+        subclass = Selector.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
 
         return subclass
 

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -6,7 +6,7 @@ Tasks related to calibrating events.
 
 import law
 
-from columnflow.tasks.framework.base import UpstreamDeps, AnalysisTask, DatasetTask, wrapper_factory
+from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorMixin, ChunkedIOMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
@@ -26,8 +26,9 @@ class CalibrateEvents(
     # default sandbox, might be overwritten by calibrator function
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
         GetDatasetLFNs=GetDatasetLFNs,
     )
 
@@ -38,7 +39,7 @@ class CalibrateEvents(
         if only_super:
             return reqs
 
-        reqs["lfns"] = self.deps.GetDatasetLFNs.req(self)
+        reqs["lfns"] = self.reqs.GetDatasetLFNs.req(self)
 
         # add calibrator dependent requirements
         reqs["calibrator"] = self.calibrator_inst.run_requires()
@@ -46,7 +47,7 @@ class CalibrateEvents(
         return reqs
 
     def requires(self):
-        reqs = {"lfns": self.deps.GetDatasetLFNs.req(self)}
+        reqs = {"lfns": self.reqs.GetDatasetLFNs.req(self)}
 
         # add calibrator dependent requirements
         reqs["calibrator"] = self.calibrator_inst.run_requires()

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -19,7 +19,7 @@ import law
 import order as od
 
 from columnflow.tasks.framework.base import (
-    UpstreamDeps, AnalysisTask, ConfigTask, DatasetTask, wrapper_factory,
+    Requirements, AnalysisTask, ConfigTask, DatasetTask, wrapper_factory,
 )
 from columnflow.util import wget, safe_div
 
@@ -362,13 +362,13 @@ class CreatePileupWeights(ConfigTask):
     )
     version = None
 
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
         BundleExternalFiles=BundleExternalFiles,
     )
 
     def requires(self):
-        return self.deps.BundleExternalFiles.req(self)
+        return self.reqs.BundleExternalFiles.req(self)
 
     def output(self):
         return self.target(f"weights_from_{self.data_mode}.json")

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -18,7 +18,9 @@ import luigi
 import law
 import order as od
 
-from columnflow.tasks.framework.base import AnalysisTask, ConfigTask, DatasetTask, wrapper_factory
+from columnflow.tasks.framework.base import (
+    UpstreamDeps, AnalysisTask, ConfigTask, DatasetTask, wrapper_factory,
+)
 from columnflow.util import wget, safe_div
 
 
@@ -360,11 +362,13 @@ class CreatePileupWeights(ConfigTask):
     )
     version = None
 
-    # default upstream dependency task classes
-    dep_BundleExternalFiles = BundleExternalFiles
+    # upstream dependencies
+    deps = UpstreamDeps(
+        BundleExternalFiles=BundleExternalFiles,
+    )
 
     def requires(self):
-        return self.dep_BundleExternalFiles.req(self)
+        return self.deps.BundleExternalFiles.req(self)
 
     def output(self):
         return self.target(f"weights_from_{self.data_mode}.json")

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -26,22 +26,22 @@ default_config = law.config.get_expanded("analysis", "default_config")
 default_dataset = law.config.get_expanded("analysis", "default_dataset")
 
 
-class UpstreamDeps(DotDict):
+class Requirements(DotDict):
 
     def __init__(self, *others, **kwargs):
         super().__init__()
 
         # add others and kwargs
-        for deps in others + (kwargs,):
-            self.update(deps)
+        for reqs in others + (kwargs,):
+            self.update(reqs)
 
 
 class BaseTask(law.Task):
 
     task_namespace = law.config.get_expanded("analysis", "cf_task_namespace", "cf")
 
-    # container for upstream dependencies for convenience
-    deps = UpstreamDeps()
+    # container for upstream requirements for convenience
+    reqs = Requirements()
 
 
 class OutputLocation(enum.Enum):
@@ -161,8 +161,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         """
         # get shifts from upstream dependencies, consider both their own and upstream shifts as one
         upstream_shifts = set()
-        for dep in cls.deps.values():
-            upstream_shifts |= set.union(*(dep.get_known_shifts(config_inst, params) or (set(),)))
+        for req in cls.reqs.values():
+            upstream_shifts |= set.union(*(req.get_known_shifts(config_inst, params) or (set(),)))
 
         return set(), upstream_shifts
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -284,6 +284,8 @@ class SelectorStepsMixin(SelectorMixin):
         brace_expand=True,
     )
 
+    exclude_params_repr_empty = {"selector_steps"}
+
     selector_steps_order_sensitive = False
 
     @classmethod
@@ -488,6 +490,8 @@ class MLModelMixin(ConfigTask):
         "'default_ml_model' config",
     )
 
+    exclude_params_repr_empty = {"ml_model"}
+
     @classmethod
     def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().modify_param_values(params)
@@ -539,6 +543,8 @@ class MLModelsMixin(ConfigTask):
         description="comma-separated names of ML models to be applied; empty default",
         brace_expand=True,
     )
+
+    exclude_params_repr_empty = {"ml_models"}
 
     @classmethod
     def modify_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -35,6 +35,9 @@ class CalibratorMixin(ConfigTask):
         "'default_calibrator' config",
     )
 
+    # decibes whether the task itself runs the calibrator and implements its shifts
+    register_calibrator_shifts = False
+
     @classmethod
     def get_default_calibrator(cls, config_inst, calibrator=None) -> str | None:
         if calibrator not in (None, law.NO_STR):
@@ -56,8 +59,8 @@ class CalibratorMixin(ConfigTask):
         return params
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the calibrator, update it and add its shifts
         calibrator = cls.get_default_calibrator(config_inst, params.get("calibrator"))
@@ -66,9 +69,12 @@ class CalibratorMixin(ConfigTask):
                 calibrator,
                 cls.get_calibrator_kwargs(**params),
             )
-            shifts |= calibrator_inst.all_shifts
+            if cls.register_calibrator_shifts:
+                shifts |= calibrator_inst.all_shifts
+            else:
+                upstream_shifts |= calibrator_inst.all_shifts
 
-        return shifts
+        return shifts, upstream_shifts
 
     @classmethod
     def get_calibrator_inst(cls, calibrator, inst_dict=None):
@@ -110,6 +116,9 @@ class CalibratorsMixin(ConfigTask):
         brace_expand=True,
     )
 
+    # decibes whether the task itself runs the calibrators and implements their shifts
+    register_calibrators_shifts = False
+
     @classmethod
     def get_default_calibrators(cls, config_inst, calibrators=None) -> tuple[str]:
         if calibrators not in (None, law.NO_STR, ()):
@@ -133,8 +142,8 @@ class CalibratorsMixin(ConfigTask):
         return params
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the calibrators, update them and add their shifts
         calibrators = cls.get_default_calibrators(config_inst, params.get("calibrators"))
@@ -142,9 +151,12 @@ class CalibratorsMixin(ConfigTask):
             calibrator_kwargs = cls.get_calibrator_kwargs(**params)
             for calibrator in calibrators:
                 calibrator_inst = cls.get_calibrator_inst(calibrator, calibrator_kwargs)
-                shifts |= calibrator_inst.all_shifts
+                if cls.register_calibrators_shifts:
+                    shifts |= calibrator_inst.all_shifts
+                else:
+                    upstream_shifts |= calibrator_inst.all_shifts
 
-        return shifts
+        return shifts, upstream_shifts
 
     @classmethod
     def get_calibrator_inst(cls, calibrator, inst_dict=None):
@@ -186,6 +198,9 @@ class SelectorMixin(ConfigTask):
         "'default_selector' config",
     )
 
+    # decibes whether the task itself runs the selector and implements its shifts
+    register_selector_shifts = False
+
     @classmethod
     def get_default_selector(cls, config_inst, selector=None) -> str | None:
         if selector not in (None, law.NO_STR):
@@ -207,8 +222,8 @@ class SelectorMixin(ConfigTask):
         return params
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the selector, update it and add its shifts
         selector = cls.get_default_selector(config_inst, params.get("selector"))
@@ -217,9 +232,12 @@ class SelectorMixin(ConfigTask):
                 selector,
                 cls.get_selector_kwargs(**params),
             )
-            shifts |= selector_inst.all_shifts
+            if cls.register_selector_shifts:
+                shifts |= selector_inst.all_shifts
+            else:
+                upstream_shifts |= selector_inst.all_shifts
 
-        return shifts
+        return shifts, upstream_shifts
 
     @classmethod
     def get_selector_inst(cls, selector, inst_dict=None):
@@ -305,6 +323,9 @@ class ProducerMixin(ConfigTask):
         "'default_producer' config",
     )
 
+    # decibes whether the task itself runs the producer and implements its shifts
+    register_producer_shifts = False
+
     @classmethod
     def get_default_producer(cls, config_inst, producer=None) -> str | None:
         if producer not in (None, law.NO_STR):
@@ -326,8 +347,8 @@ class ProducerMixin(ConfigTask):
         return params
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the producer, update it and add its shifts
         producer = cls.get_default_producer(config_inst, params.get("producer"))
@@ -336,9 +357,12 @@ class ProducerMixin(ConfigTask):
                 producer,
                 cls.get_producer_kwargs(**params),
             )
-            shifts |= producer_inst.all_shifts
+            if cls.register_producer_shifts:
+                shifts |= producer_inst.all_shifts
+            else:
+                upstream_shifts |= producer_inst.all_shifts
 
-        return shifts
+        return shifts, upstream_shifts
 
     @classmethod
     def get_producer_inst(cls, producer, inst_dict=None):
@@ -380,6 +404,9 @@ class ProducersMixin(ConfigTask):
         brace_expand=True,
     )
 
+    # decibes whether the task itself runs the producers and implements their shifts
+    register_producers_shifts = False
+
     @classmethod
     def get_default_producers(cls, config_inst, producers=None) -> tuple[str]:
         if producers not in (None, law.NO_STR, ()):
@@ -403,8 +430,8 @@ class ProducersMixin(ConfigTask):
         return params
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the producers, update them and add their shifts
         producers = cls.get_default_producers(config_inst, params.get("producers"))
@@ -412,9 +439,12 @@ class ProducersMixin(ConfigTask):
             producer_kwargs = cls.get_producer_kwargs(**params)
             for producer in producers:
                 producer_inst = cls.get_producer_inst(producer, producer_kwargs)
-                shifts |= producer_inst.all_shifts
+                if cls.register_producers_shifts:
+                    shifts |= producer_inst.all_shifts
+                else:
+                    upstream_shifts |= producer_inst.all_shifts
 
-        return shifts
+        return shifts, upstream_shifts
 
     @classmethod
     def get_producer_inst(cls, producer, inst_dict=None):
@@ -902,13 +932,13 @@ class ShiftSourcesMixin(ConfigTask):
 class EventWeightMixin(ConfigTask):
 
     @classmethod
-    def get_allowed_shifts(cls, config_inst, params):
-        allowed_shifts = super().get_allowed_shifts(config_inst, params)
+    def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
+        shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # add shifts introduced by event weights
         if config_inst.has_aux("event_weights"):
             for shift_insts in config_inst.x.event_weights.values():
-                allowed_shifts |= {shift_inst.name for shift_inst in shift_insts}
+                shifts |= {shift_inst.name for shift_inst in shift_insts}
 
         # optionally also for weights defined by a dataset
         if "dataset" in params:
@@ -917,9 +947,9 @@ class EventWeightMixin(ConfigTask):
                 dataset_inst = config_inst.get_dataset(requested_dataset)
                 if dataset_inst.has_aux("event_weights"):
                     for shift_insts in dataset_inst.x.event_weights.values():
-                        allowed_shifts |= {shift_inst.name for shift_inst in shift_insts}
+                        shifts |= {shift_inst.name for shift_inst in shift_insts}
 
-        return allowed_shifts
+        return shifts, upstream_shifts
 
 
 class ChunkedIOMixin(AnalysisTask):

--- a/columnflow/tasks/inference.py
+++ b/columnflow/tasks/inference.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 import law
 
-from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.base import UpstreamDeps, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
@@ -32,6 +32,12 @@ class CreateDatacards(
     dep_MergeHistograms = MergeHistograms
     dep_MergeShiftedHistograms = MergeShiftedHistograms
 
+    # upstream dependencies
+    deps = UpstreamDeps(
+        MergeHistograms=MergeHistograms,
+        MergeShiftedHistograms=MergeShiftedHistograms,
+    )
+
     def create_branch_map(self):
         return list(self.inference_model_inst.categories)
 
@@ -52,7 +58,7 @@ class CreateDatacards(
         cat_obj = self.branch_data
         reqs = {
             proc_obj.name: {
-                dataset: self.dep_MergeShiftedHistograms.req(
+                dataset: self.deps.MergeShiftedHistograms.req(
                     self,
                     dataset=dataset,
                     shift_sources=tuple(
@@ -70,7 +76,7 @@ class CreateDatacards(
         }
         if cat_obj.config_data_datasets:
             reqs["data"] = {
-                dataset: self.dep_MergeHistograms.req(
+                dataset: self.deps.MergeHistograms.req(
                     self,
                     dataset=dataset,
                     variables=(cat_obj.config_variable,),

--- a/columnflow/tasks/inference.py
+++ b/columnflow/tasks/inference.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 import law
 
-from columnflow.tasks.framework.base import UpstreamDeps, AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, InferenceModelMixin,
 )
@@ -28,12 +28,9 @@ class CreateDatacards(
 ):
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    # default upstream dependency task classes
-    dep_MergeHistograms = MergeHistograms
-    dep_MergeShiftedHistograms = MergeShiftedHistograms
-
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
         MergeHistograms=MergeHistograms,
         MergeShiftedHistograms=MergeShiftedHistograms,
     )
@@ -58,7 +55,7 @@ class CreateDatacards(
         cat_obj = self.branch_data
         reqs = {
             proc_obj.name: {
-                dataset: self.deps.MergeShiftedHistograms.req(
+                dataset: self.reqs.MergeShiftedHistograms.req(
                     self,
                     dataset=dataset,
                     shift_sources=tuple(
@@ -76,7 +73,7 @@ class CreateDatacards(
         }
         if cat_obj.config_data_datasets:
             reqs["data"] = {
-                dataset: self.deps.MergeHistograms.req(
+                dataset: self.reqs.MergeHistograms.req(
                     self,
                     dataset=dataset,
                     variables=(cat_obj.config_variable,),

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 import law
 import luigi
 
-from columnflow.tasks.framework.base import UpstreamDeps, ShiftTask
+from columnflow.tasks.framework.base import Requirements, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
     CategoriesMixin, ShiftSourcesMixin,
@@ -39,8 +39,9 @@ class PlotVariablesBase(
 
     exclude_index = True
 
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
         MergeHistograms=MergeHistograms,
     )
 
@@ -167,8 +168,9 @@ class PlotVariablesBaseSingleShift(
 ):
     exclude_index = True
 
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
+        PlotVariablesBase.reqs,
         MergeHistograms=MergeHistograms,
     )
 
@@ -181,7 +183,7 @@ class PlotVariablesBaseSingleShift(
 
     def requires(self):
         return {
-            d: self.deps.MergeHistograms.req(
+            d: self.reqs.MergeHistograms.req(
                 self,
                 dataset=d,
                 branch=-1,
@@ -249,8 +251,9 @@ class PlotVariablesBaseMultiShifts(
 
     exclude_index = True
 
-    # upstream dependencies
-    deps = UpstreamDeps(
+    # upstream requirements
+    reqs = Requirements(
+        PlotVariablesBase.reqs,
         MergeShiftedHistograms=MergeShiftedHistograms,
     )
 
@@ -264,7 +267,7 @@ class PlotVariablesBaseMultiShifts(
 
     def requires(self):
         return {
-            d: self.deps.MergeShiftedHistograms.req(
+            d: self.reqs.MergeShiftedHistograms.req(
                 self,
                 dataset=d,
                 branch=-1,
@@ -313,8 +316,14 @@ class PlotShiftedVariablesPerProcess1D(
     # force this one to be a local workflow
     workflow = "local"
 
+    # upstream requirements
+    reqs = Requirements(
+        PlotShiftedVariables1D.reqs,
+        PlotShiftedVariables1D=PlotShiftedVariables1D,
+    )
+
     def requires(self):
         return {
-            process: PlotShiftedVariables1D.req(self, processes=(process,))
+            process: self.reqs.PlotShiftedVariables1D.req(self, processes=(process,))
             for process in self.processes
         }

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -6,7 +6,7 @@ Tasks related to producing new columns.
 
 import law
 
-from columnflow.tasks.framework.base import UpstreamDeps, AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducerMixin, ChunkedIOMixin,
 )
@@ -27,9 +27,10 @@ class ProduceColumns(
     # default sandbox, might be overwritten by producer function
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    # upstream dependencies
-    deps = UpstreamDeps(
-        MergeReducedEventsUser.deps,
+    # upstream requirements
+    reqs = Requirements(
+        MergeReducedEventsUser.reqs,
+        RemoteWorkflow.reqs,
         MergeReducedEvents=MergeReducedEvents,
     )
 
@@ -41,7 +42,7 @@ class ProduceColumns(
             return reqs
 
         # require the full merge forest
-        reqs["events"] = self.deps.MergeReducedEvents.req(self, tree_index=-1)
+        reqs["events"] = self.reqs.MergeReducedEvents.req(self, tree_index=-1)
 
         # add producer dependent requirements
         reqs["producer"] = self.producer_inst.run_requires()
@@ -50,7 +51,7 @@ class ProduceColumns(
 
     def requires(self):
         return {
-            "events": self.deps.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+            "events": self.reqs.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
             "producer": self.producer_inst.run_requires(),
         }
 

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -6,7 +6,7 @@ Task to unite columns horizontally into a single file for further, possibly exte
 
 import law
 
-from columnflow.tasks.framework.base import UpstreamDeps, AnalysisTask, wrapper_factory
+from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, ChunkedIOMixin,
 )
@@ -29,9 +29,10 @@ class UniteColumns(
 ):
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
-    # upstream dependencies
-    deps = UpstreamDeps(
-        MergeReducedEvents.deps,
+    # upstream requirements
+    reqs = Requirements(
+        MergeReducedEvents.reqs,
+        RemoteWorkflow.reqs,
         MergeReducedEvents=MergeReducedEvents,
         ProduceColumns=ProduceColumns,
         MLEvaluation=MLEvaluation,
@@ -43,17 +44,17 @@ class UniteColumns(
             return reqs
 
         # require the full merge forest
-        reqs["events"] = self.deps.MergeReducedEvents.req(self, tree_index=-1)
+        reqs["events"] = self.reqs.MergeReducedEvents.req(self, tree_index=-1)
 
         if not self.pilot:
             if self.producers:
                 reqs["producers"] = [
-                    self.deps.ProduceColumns.req(self, producer=p)
+                    self.reqs.ProduceColumns.req(self, producer=p)
                     for p in self.producers
                 ]
             if self.ml_models:
                 reqs["ml"] = [
-                    self.deps.MLEvaluation.req(self, ml_model=m)
+                    self.reqs.MLEvaluation.req(self, ml_model=m)
                     for m in self.ml_models
                 ]
 
@@ -61,17 +62,17 @@ class UniteColumns(
 
     def requires(self):
         reqs = {
-            "events": self.deps.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+            "events": self.reqs.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
         }
 
         if self.producers:
             reqs["producers"] = [
-                self.deps.ProduceColumns.req(self, producer=p)
+                self.reqs.ProduceColumns.req(self, producer=p)
                 for p in self.producers
             ]
         if self.ml_models:
             reqs["ml"] = [
-                self.deps.MLEvaluation.req(self, ml_model=m)
+                self.reqs.MLEvaluation.req(self, ml_model=m)
                 for m in self.ml_models
             ]
 

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -741,6 +741,7 @@ class DerivableMeta(type):
         cls_name: str,
         bases: tuple = (),
         cls_dict: dict | None = None,
+        module: str | None = None,
     ) -> DerivableMeta:
         """
         Creates a subclass named *cls_name* inheriting from *this* class an additional, optional
@@ -753,8 +754,9 @@ class DerivableMeta(type):
         subcls = cls.__class__(cls_name, (cls,) + bases, cls_dict or {})
 
         # overwrite __module__ to point to the module of the calling stack
-        frame = inspect.stack()[1]
-        module = inspect.getmodule(frame[0])
+        if not module:
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
         if module:
             subcls.__module__ = module.__name__
 


### PR DESCRIPTION
This PR refactors (and fixes) the resolution of systematic shifts.

So far, tasks obtained a `--shift`, checked if they and any upstream dependency implements that shift, and if so, would set their `effective_shift` to this value. The requested shift was always passed upstream. However, since the `shift` parameter itself is significant (as it should be), situations such as in #146 could arise.

This mechanism is greatly improved by this PR. There is now a full distinction between shifts that a task implement itself, and shifts that are handled by upstream dependencies. We have this info since we - at all times - know which producers / selectors / calibrators are run where and when.

As a result, tasks have two shift instances now - `requested_shift_inst` and `effective_shift_inst` - of which the latter was the one defined as `shift_inst` before, and by which attribute it is still accessible (via a read-only getter) since it's the shift that one usually needs to access. The mechanism above is changed such that the shift parameter itself is changed to "nominal" in case neither the task itself nor a dependency is implementing it, so that there is no need to *bubble up* this value.

Also, the class attributes that we use to allow analyses to change any task dependency and injecting custom tasks (e.g. `dep_ProduceColumns` in the `CreateHistograms` task) are now bundled through a shallow dict container. Creating the required task for a `CreateHistograms` task would then become

```python
# old
self.dep_ProduceColumns.req(self)

# new
self.reqs.ProduceColumns.req(self)
```

with `self.reqs` being essentially a DotDict.

The mechanism that it replaces hasn't been reviewed before and is buggy in edge cases, which is why this PR is a high-priority fix.

Fixes #146.