### PR TITLE
Share prepared ML events between ML models.

### DIFF
--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -76,6 +76,10 @@ class MLModel(Derivable):
     # default number of folds
     folds = 2
 
+    # default name for storing e.g. input data
+    # falls back to cls_name if None
+    store_name = None
+
     def __init__(
         self,
         config_inst: od.Config,

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -29,6 +29,9 @@ class PrepareMLEvents(
 ):
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
+    allow_empty_ml_model = False
+    use_store_name_from_ml_model = True
+
     # upstream requirements
     reqs = Requirements(
         MergeReducedEventsUser.reqs,
@@ -202,6 +205,9 @@ class MergeMLEvents(
     # in each step, merge 10 into 1
     merge_factor = 10
 
+    allow_empty_ml_model = False
+    use_store_name_from_ml_model = True
+
     # upstream requirements
     reqs = Requirements(
         RemoteWorkflow.reqs,
@@ -274,6 +280,8 @@ class MLTraining(
         "the number of folds defined in the ML model; default: 0",
     )
 
+    allow_empty_ml_model = False
+
     # upstream requirements
     reqs = Requirements(
         MergeMLEvents=MergeMLEvents,
@@ -337,6 +345,8 @@ class MLEvaluation(
     RemoteWorkflow,
 ):
     sandbox = None
+
+    allow_empty_ml_model = False
 
     # upstream requirements
     reqs = Requirements(

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -9,7 +9,7 @@ import luigi
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorMixin, ProducersMixin, MLModelMixin, ChunkedIOMixin,
+    CalibratorsMixin, SelectorMixin, ProducersMixin, MLModelDataMixin, MLModelMixin, ChunkedIOMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
@@ -18,7 +18,7 @@ from columnflow.util import dev_sandbox, safe_div
 
 
 class PrepareMLEvents(
-    MLModelMixin,
+    MLModelDataMixin,
     ProducersMixin,
     SelectorMixin,
     CalibratorsMixin,
@@ -30,7 +30,6 @@ class PrepareMLEvents(
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     allow_empty_ml_model = False
-    use_store_name_from_ml_model = True
 
     # upstream requirements
     reqs = Requirements(
@@ -181,7 +180,7 @@ PrepareMLEventsWrapper = wrapper_factory(
 
 
 class MergeMLEvents(
-    MLModelMixin,
+    MLModelDataMixin,
     ProducersMixin,
     SelectorMixin,
     CalibratorsMixin,
@@ -206,7 +205,6 @@ class MergeMLEvents(
     merge_factor = 10
 
     allow_empty_ml_model = False
-    use_store_name_from_ml_model = True
 
     # upstream requirements
     reqs = Requirements(

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,5 +1,7 @@
-# version 4
+# version 5
 
 tensorflow~=2.11
+git+https://github.com/CoffeaTeam/coffea.git@b9356b9#egg=coffea
 awkward~=2.0
 dask-awkward~=2023.1
+tabulate~=0.9


### PR DESCRIPTION
So far, each ML model requires its own minimal data preprocessing pipeline consisting of

```mermaid
graph TD
    PrepareMLEvents(PrepareMLEvents)
    MergeMLEvents(MergeMLEvents)
    MLTraining(MLTraining)

    PrepareMLEvents ==folds==> MergeMLEvents
    MergeMLEvents --folds--> MLTraining
```

However, two or more models that could require the same inputs strictly trigger different pipelines which is extremely redundant.

This PR adds a slightly different mixin for the `{Prepare,Merge}MLEvents` task that does not add the model name to the store path, but rather a configurable `store_name`. When *None* (the default), it falls back to the model name (`cls_name`) though.

The additional mixin is needed since for the two task classes mentioned above, the model itself is actually not significant but just its `store_name` attribute. This is achieved through a hidden parameter (as also done in many other places) that ensures significance in the luigi context.