### PR TITLE
Use mc_only switches in producers / calibrators.

### DIFF
--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -19,7 +19,8 @@ ak = maybe_import("awkward")
     uses={
         "Jet.hadronFlavour", "Jet.eta", "Jet.pt", "Jet.btagDeepFlavB",
     },
-    # produced columns are defined in the init function below
+    # only run on mc
+    mc_only=True,
 )
 def btag_weights(
     self: Producer,
@@ -51,10 +52,6 @@ def btag_weights(
        - https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration?rev=26
        - https://indico.cern.ch/event/1096988/contributions/4615134/attachments/2346047/4000529/Nov21_btaggingSFjsons.pdf
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute btag weights in data")
-
     # get the total number of jets in the chunk
     n_jets_all = ak.sum(ak.num(events.Jet, axis=1))
 

--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -22,6 +22,8 @@ ak = maybe_import("awkward")
     produces={
         "electron_weight", "electron_weight_up", "electron_weight_down",
     },
+    # only run on mc
+    mc_only=True,
 )
 def electron_weights(
     self: Producer,
@@ -47,10 +49,6 @@ def electron_weights(
     Optionally, an *electron_mask* can be supplied to compute the scale factor weight
     based only on a subset of electrons.
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute electron weights in data")
-
     # get year string and working point name
     sf_year, wp = self.config_inst.x.electron_sf_names[1:]
 

--- a/columnflow/production/cms/mc_weight.py
+++ b/columnflow/production/cms/mc_weight.py
@@ -16,6 +16,8 @@ ak = maybe_import("awkward")
 @producer(
     uses={"genWeight", "LHEWeight.originalXWGTUP"},
     produces={"mc_weight"},
+    # only run on mc
+    mc_only=True,
 )
 def mc_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -30,10 +32,6 @@ def mc_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     [1] https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookNanoAOD?rev=99#Weigths
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute mc_weight in data")
-
     # determine the mc_weight
     mc_weight = events.genWeight
     if has_ak_column(events, "LHEWeight.originalXWGTUP") and ak.all(events.genWeight == 1.0):

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -22,6 +22,8 @@ ak = maybe_import("awkward")
     produces={
         "muon_weight", "muon_weight_up", "muon_weight_down",
     },
+    # only run on mc
+    mc_only=True,
 )
 def muon_weights(
     self: Producer,
@@ -50,10 +52,6 @@ def muon_weights(
     Optionally, a *muon_mask* can be supplied to compute the scale factor weight
     based only on a subset of muons.
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute muon weights in data")
-
     # get year string
     sf_year = self.config_inst.x.muon_sf_names[1]
 

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -27,6 +27,8 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
     produces={
         "pdf_weight", "pdf_weight_up", "pdf_weight_down",
     },
+    # only run on mc
+    mc_only=True,
 )
 def pdf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -39,10 +41,6 @@ def pdf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
        - https://arxiv.org/pdf/1510.03865.pdf
     """
-    # stop here for data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to determine pdf variations in data")
-
     # check for the correct amount of weights
     n_weights = ak.num(events.LHEPdfWeight, axis=1)
     bad_mask = (n_weights != 101) & (n_weights != 103)

--- a/columnflow/production/cms/pileup.py
+++ b/columnflow/production/cms/pileup.py
@@ -21,6 +21,8 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 @producer(
     uses={"PV.npvs"},
     produces={"pu_weight", "pu_weight_minbias_xs_up", "pu_weight_minbias_xs_down"},
+    # only run on mc
+    mc_only=True,
 )
 def pu_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -28,10 +30,6 @@ def pu_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     of pileup ratios at the py:attr:`pu_weights` attribute provided by the requires and setup
     functions below.
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute pileup weights in data")
-
     # compute the indices for looking up weights
     indices = events.PV.npvs.to_numpy() - 1
     max_bin = len(self.pu_weights) - 1

--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -29,6 +29,8 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
         "muf_weight", "muf_weight_up", "muf_weight_down",
         "murmuf_weight", "murmuf_weight_up", "murmuf_weight_down",
     },
+    # only run on mc
+    mc_only=True,
 )
 def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -40,10 +42,6 @@ def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     Resources:
         - https://cms-nanoaod-integration.web.cern.ch/integration/master/mc94X_doc.html
     """
-    # stop here for data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to read out mur/muf weights in data")
-
     n_weights = ak.num(events.LHEScaleWeight, axis=1)
     if ak.any(n_weights != 9):
         bad_values = set(n_weights[n_weights != 9])
@@ -84,6 +82,8 @@ def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 @producer(
     uses={"LHEScaleWeight"},
     produces={"murf_envelope_weight", "murf_envelope_weight_up", "murf_envelope_weight_down"},
+    # only run on mc
+    mc_only=True,
 )
 def murmuf_envelope_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -95,10 +95,6 @@ def murmuf_envelope_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Ar
     Resources:
         - https://cms-nanoaod-integration.web.cern.ch/integration/master/mc94X_doc.html
     """
-    # stop here for data
-    if self.dataset_inst.is_data:
-        return events
-
     n_weights = ak.num(events.LHEScaleWeight, axis=1)
     if ak.any(n_weights != 9):
         bad_values = set(n_weights[n_weights != 9])

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -19,6 +19,8 @@ ak = maybe_import("awkward")
 @producer(
     uses={process_ids, "mc_weight"},
     produces={process_ids, "normalization_weight"},
+    # only run on mc
+    mc_only=True,
 )
 def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -26,10 +28,6 @@ def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Arra
     obtained through :py:class:`category_ids` and the sum of event weights from the
     py:attr:`selection_stats` attribute to assign each event a normalization weight.
     """
-    # fail when running on data
-    if self.dataset_inst.is_data:
-        raise ValueError("attempt to compute normalization weights in data")
-
     # add process ids
     events = self[process_ids](events, **kwargs)
 

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,6 +1,6 @@
 # version 7
 
-git+https://github.com/CoffeaTeam/coffea.git@b9356b9#egg=coffea
+git+https://github.com/CoffeaTeam/coffea.git@3769a4d#egg=coffea
 awkward~=2.0
 dask-awkward~=2023.1
 uproot~=5.0

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,7 +1,7 @@
 # version 5
 
 tensorflow~=2.11
-git+https://github.com/CoffeaTeam/coffea.git@b9356b9#egg=coffea
+git+https://github.com/CoffeaTeam/coffea.git@3769a4d#egg=coffea
 awkward~=2.0
 dask-awkward~=2023.1
 tabulate~=0.9


### PR DESCRIPTION
This PR adds `mc_only` flags to some producers and calibrators which let's cf decide on whether to include them in the dependency tree of other producers in case data is processed. This information is used to fully skip them, meaning that their requested columns are not loaded, nor can they be called in the first place - they would raise an exception instead. The latter allows to remove the "manual" exceptions that were thrown before in case a producer was called on data.

As described in #154, this also makes most producers custom `init` function, which usually was only used to *add* certain producers in case mc was handled, obsolete.

Closes #154.