### PR TITLE
Allow missing 'objects' in selection results.

### DIFF
--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -173,7 +173,7 @@ class ReduceEvents(
 
             # loop through all object selection, go through their masks
             # and create new collections if required
-            if hasattr(sel, "objects"):
+            if "objects" in sel.fields:
                 for src_name in sel.objects.fields:
                     # get all destination collections, handling those named identically to the
                     # source collection last


### PR DESCRIPTION
This PR handles the case where no `objects` are specified in the `SelectionResult` returned by an exposed selector.