### PR TITLE
Top-to-bottom ordering of stacked processes.

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -207,12 +207,34 @@ def plot_all(
 
     # legend
     if not skip_legend:
+        # resolve legend kwargs
         legend_kwargs = {
             "ncol": 1,
             "loc": "upper right",
         }
         legend_kwargs.update(style_config.get("legend_cfg", {}))
-        ax.legend(**legend_kwargs)
+
+        # retrieve the legend handles and their labels
+        handles, labels = ax.get_legend_handles_labels()
+
+        # assume all `StepPatch` objects are part of MC stack
+        in_stack = [
+            isinstance(handle, mpl.patches.StepPatch)
+            for handle in handles
+        ]
+
+        # reverse order of entries that are part of the stack
+        if any(in_stack):
+            def shuffle(entries, mask):
+                entries = np.array(entries, dtype=object)
+                entries[mask] = entries[mask][::-1]
+                return list(entries)
+
+            handles = shuffle(handles, in_stack)
+            labels = shuffle(labels, in_stack)
+
+        # make legend using ordered handles/labels
+        ax.legend(handles, labels, **legend_kwargs)
 
     # custom annotation
     annotate_kwargs = {

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -214,7 +214,9 @@ def prepare_plot_config(
         h_data = sum(data_hists[1:], data_hists[0].copy())
     if mc_hists:
         h_mc = sum(mc_hists[1:], mc_hists[0].copy())
-        h_mc_stack = hist.Stack(*mc_hists)
+        # reverse hists when building MC stack so that the
+        # first process is on top
+        h_mc_stack = hist.Stack(*mc_hists[::-1])
 
     # setup plotting configs
     plot_config = OrderedDict()
@@ -227,10 +229,10 @@ def prepare_plot_config(
             "hist": h_mc_stack,
             "kwargs": {
                 "norm": mc_norm,
-                "label": mc_labels,
-                "color": mc_colors,
-                "edgecolor": mc_edgecolors,
-                "linewidth": [(0 if c is None else 1) for c in line_colors],
+                "label": mc_labels[::-1],
+                "color": mc_colors[::-1],
+                "edgecolor": mc_edgecolors[::-1],
+                "linewidth": [(0 if c is None else 1) for c in mc_colors[::-1]],
             },
         }
         plot_config["mc_uncert"] = {


### PR DESCRIPTION
This PR changes the order in which processes are plotted as part of a stacked histogram, so that their order from top to bottom corresponds to the one given via the `processes` task parameter.

In the current implementation, the order of the stacked processes appears to be reversed. While this ordering technically makes sense when considering that the stack is constructed from the bottom up, it seems to me somewhat counter-intuitive, as I would expect the first named process to appear at the top.

Another related issue addressed by this PR is the ordering of the legend handles, which I think should be sorted so that they visually match the process stack.