### PR TITLE
Remove need for multiple alias dicts per shift.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -183,7 +183,6 @@ add_shift_aliases(
         "MET.pt": "MET.pt_{name}",
         "MET.phi": "MET.phi_{name}",
     },
-    selection_dependent=True,
 )
 
 # event weights due to muon scale factors

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -726,6 +726,7 @@ def add_ak_alias(
     src_route: Route | Sequence[str] | str,
     dst_route: Route | Sequence[str] | str,
     remove_src: bool = False,
+    missing_strategy: str = "original",
 ) -> ak.Array:
     """
     Adds an alias to an awkward array *ak_array* pointing the array at *src_route* to *dst_route*
@@ -733,23 +734,37 @@ def add_ak_alias(
 
     Note that existing columns referred to by *dst_route* might be overwritten. When *remove_src* is
     *True*, a view of the input array is returned with the column referred to by *src_route*
-    missing.
+    missing. Both routes can be :py:class:`Route` instances, a tuple of strings where each string
+    refers to a subfield, e.g. ``("Jet", "pt")``, or a string with dot format (e.g. ``"Jet.pt"``).
 
-    Both routes can be a :py:class:`Route` instance, a tuple of strings where each string refers to
-    a subfield, e.g. ``("Jet", "pt")``, or a string with dot format (e.g. ``"Jet.pt"``). A
-    *ValueError* is raised when *src_route* does not exist.
+    In case *src_route* does not exist, *missing_strategy* is applied:
+
+        - ``"original"``: If existing, *dst_route* remains unchanged.
+        - ``"remove"``: If existing, *dst_route* is removed.
+        - ``"raise"``: A *ValueError* is raised.
     """
+    # check the strategy
+    strategies = ("original", "remove", "raise")
+    if missing_strategy not in strategies:
+        raise ValueError(
+            f"unknown missing_strategy '{missing_strategy}', valid values are {strategies}",
+        )
+
+    # convert to routes
     src_route = Route(src_route)
     dst_route = Route(dst_route)
 
     # check that the src exists
-    if not has_ak_column(ak_array, src_route):
-        raise ValueError(f"no column found in array for route '{src_route}'")
+    if has_ak_column(ak_array, src_route):
+        # add the alias, potentially overwriting existing columns
+        ak_array = set_ak_column(ak_array, dst_route, src_route.apply(ak_array))
+    else:
+        if missing_strategy == "raise":
+            raise ValueError(f"no column found in array for route '{src_route}'")
+        if missing_strategy == "remove":
+            ak_array = remove_ak_column(ak_array, dst_route)
 
-    # add the alias, potentially overwriting existing columns
-    ak_array = set_ak_column(ak_array, dst_route, src_route.apply(ak_array))
-
-    # create a view without the source if requested
+    # remove the source column
     if remove_src:
         ak_array = remove_ak_column(ak_array, src_route)
 
@@ -759,22 +774,21 @@ def add_ak_alias(
 def add_ak_aliases(
     ak_array: ak.Array,
     aliases: dict[Route | Sequence[str] | str, Route | Sequence[str], str],
-    remove_src: bool = False,
+    **kwargs: dict[str, Any],
 ) -> ak.Array:
     """
     Adds multiple *aliases*, given in a dictionary mapping destination columns to source columns, to
     an awkward array *ak_array* and returns a new view with the aliases applied.
 
-    When *remove_src* is *True*, a view of the input array is returned with all source columns
-    missing.
-
     Each column in this dictionary can be referred to by a :py:class:`Route` instance, a tuple of
     strings where each string refers to a subfield, e.g. ``("Jet", "pt")``, or a string with dot
-    format (e.g. ``"Jet.pt"``). See :py:func:`add_ak_aliases` for more info.
+    format (e.g. ``"Jet.pt"``).
+
+    All additional *kwargs* are forwarded to :py:func:`add_ak_aliases`.
     """
     # add all aliases
     for dst_route, src_route in aliases.items():
-        ak_array = add_ak_alias(ak_array, src_route, dst_route, remove_src=remove_src)
+        ak_array = add_ak_alias(ak_array, src_route, dst_route, **kwargs)
 
     return ak_array
 

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -726,7 +726,7 @@ def add_ak_alias(
     src_route: Route | Sequence[str] | str,
     dst_route: Route | Sequence[str] | str,
     remove_src: bool = False,
-    missing_strategy: str = "original",
+    missing_strategy: str = "remove",
 ) -> ak.Array:
     """
     Adds an alias to an awkward array *ak_array* pointing the array at *src_route* to *dst_route*

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -39,14 +39,10 @@ def add_shift_aliases(
     config: od.Config,
     shift_source: str,
     aliases: dict,
-    selection_dependent: bool = False,
 ) -> None:
     """
     Extracts the two up and down shift instances from a *config* corresponding to a *shift_source*
     (i.e. the name of a shift without directions) and assigns *aliases* to their auxiliary data.
-
-    To mark whether these aliases influence variables that are used during the selection, the
-    *selection_dependent* flag can be set.
 
     Aliases should be given in a dictionary, mapping alias targets (keys) to sources (values). In
     both strings, template variables are injected with fields corresponding to all
@@ -60,15 +56,14 @@ def add_shift_aliases(
         # adds {"pdf_weight": "pdf_weight_up"} to the "pdf_up" shift in "config"
         # plus {"pdf_weight": "pdf_weight_down"} to the "pdf_down" shift in "config"
     """
-    aux_key = "column_aliases" + ("_selection_dependent" if selection_dependent else "")
     for direction in ["up", "down"]:
         shift = config.get_shift(od.Shift.join_name(shift_source, direction))
-        _aliases = shift.x(aux_key, {})
+        _aliases = shift.x("column_aliases", {})
         # format keys and values
         inject_shift = lambda s: re.sub(r"\{([^_])", r"{_\1", s).format(**shift.__dict__)
         _aliases.update({inject_shift(key): inject_shift(value) for key, value in aliases.items()})
         # extend existing or register new column aliases
-        shift.set_aux(aux_key, _aliases)
+        shift.x.column_aliases = _aliases
 
 
 def get_shifts_from_sources(config: od.Config, *shift_sources: str) -> list[od.Shift]:

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -95,7 +95,7 @@ class ReduceEvents(
         tmp_dir.touch()
 
         # get shift dependent aliases
-        aliases = self.shift_inst.x("column_aliases_selection_dependent", {})
+        aliases = self.shift_inst.x("column_aliases", {})
 
         # define columns that will be written
         write_columns = set(self.config_inst.x.keep_columns.get(self.task_family, ["*"]))

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -115,7 +115,7 @@ class SelectEvents(
         tmp_dir.touch()
 
         # get shift dependent aliases
-        aliases = self.shift_inst.x("column_aliases_selection_dependent", {})
+        aliases = self.shift_inst.x("column_aliases", {})
 
         # define columns that need to be read
         read_columns = mandatory_coffea_columns | self.selector_inst.used_columns | set(aliases.values())

--- a/tests/test_columnar_util.py
+++ b/tests/test_columnar_util.py
@@ -624,12 +624,14 @@ class ColumnarUtilFunctionsTest(unittest.TestCase):
         )
         self.test_get_ak_routes()
 
-        # error handling
+        # handling missing sources
+        arr = add_ak_alias(self.array, "Muon.pt", "Muon_pt")
+        arr2 = add_ak_alias(arr, "not_existing", "Muon_pt", missing_strategy="original")
+        self.assertTrue(has_ak_column(arr2, "Muon_pt"))
+        arr2 = add_ak_alias(arr, "not_existing", "Muon_pt", missing_strategy="remove")
+        self.assertFalse(has_ak_column(arr2, "Muon_pt"))
         with self.assertRaises(ValueError):
-            add_ak_alias(self.array, "not_existing", "")
-        with self.assertRaises(ValueError):
-            add_ak_alias(self.array, "not_existing", "Muon_pt")
-        add_ak_alias(self.array, "Jet.pt", "Jet_pt")
+            add_ak_alias(arr, "not_existing", "dst", missing_strategy="raise")
 
     def test_update_ak_array(self):
         # define additional content


### PR DESCRIPTION
As the titles says, this PRs removes the need for maintaining multiple dictionaries of shift aliases, depending on where they are applied.

This is possible with #180 merged and only requires a small change to `columnar_util.add_ak_alias` to treat cases where source columns are not present. The default is now that the target columns are removed that would cause to a verbose error in case the column is needed.

- [x] Adjust tests.
- [x] Wait for #180 to be merged first.