### PR TITLE
Use shallow od object copies in plotting.

### DIFF
--- a/columnflow/__version__.py
+++ b/columnflow/__version__.py
@@ -6,7 +6,7 @@ columnflow
 Columnar analysis backed by law and order.
 """
 
-__author__ = "columnflow Team"
+__author__ = "The Columnflow Team"
 __email__ = "todo@uni-hamburg.de"
 __copyright__ = "Copyright 2022-2023"
 __credits__ = [

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -356,7 +356,7 @@ class PlotCutflow(
 
             # sort hists by process order
             hists = OrderedDict(
-                (process_inst.copy(), hists[process_inst])
+                (process_inst.copy_shallow(), hists[process_inst])
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
@@ -365,7 +365,7 @@ class PlotCutflow(
                 self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
-                category_inst=category_inst.copy(),
+                category_inst=category_inst.copy_shallow(),
                 **self.get_plot_parameters(),
             )
 
@@ -584,7 +584,7 @@ class PlotCutflowVariables1D(
         if self.per_plot == "processes":
             for step in self.chosen_steps:
                 step_hists = OrderedDict(
-                    (process_inst.copy(), h[{"step": hist.loc(step)}])
+                    (process_inst.copy_shallow(), h[{"step": hist.loc(step)}])
                     for process_inst, h in hists.items()
                 )
 
@@ -593,8 +593,8 @@ class PlotCutflowVariables1D(
                     self.plot_function_per_process,
                     hists=step_hists,
                     config_inst=self.config_inst,
-                    category_inst=category_inst.copy(),
-                    variable_insts=[var_inst.copy() for var_inst in variable_insts],
+                    category_inst=category_inst.copy_shallow(),
+                    variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
                     style_config={"legend_cfg": {"title": f"Step '{step}'"}},
                     **self.get_plot_parameters(),
                 )
@@ -615,8 +615,8 @@ class PlotCutflowVariables1D(
                     self.plot_function_per_step,
                     hists=process_hists,
                     config_inst=self.config_inst,
-                    category_inst=category_inst.copy(),
-                    variable_insts=[var_inst.copy() for var_inst in variable_insts],
+                    category_inst=category_inst.copy_shallow(),
+                    variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
                     style_config={"legend_cfg": {"title": process_inst.label}},
                     **self.get_plot_parameters(),
                 )
@@ -653,7 +653,7 @@ class PlotCutflowVariables2D(
 
         for step in self.chosen_steps:
             step_hists = OrderedDict(
-                (process_inst.copy(), h[{"step": hist.loc(step)}])
+                (process_inst.copy_shallow(), h[{"step": hist.loc(step)}])
                 for process_inst, h in hists.items()
             )
 
@@ -662,8 +662,8 @@ class PlotCutflowVariables2D(
                 self.plot_function,
                 hists=step_hists,
                 config_inst=self.config_inst,
-                category_inst=category_inst.copy(),
-                variable_insts=[var_inst.copy() for var_inst in variable_insts],
+                category_inst=category_inst.copy_shallow(),
+                variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
                 style_config={"legend_cfg": {"title": f"Step '{step}'"}},
                 **self.get_plot_parameters(),
             )

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -143,7 +143,7 @@ class PlotVariablesBase(
 
             # sort hists by process order
             hists = OrderedDict(
-                (process_inst.copy(), hists[process_inst])
+                (process_inst.copy_shallow(), hists[process_inst])
                 for process_inst in sorted(hists, key=process_insts.index)
             )
 
@@ -152,8 +152,8 @@ class PlotVariablesBase(
                 self.plot_function,
                 hists=hists,
                 config_inst=self.config_inst,
-                category_inst=category_inst.copy(),
-                variable_insts=[var_inst.copy() for var_inst in variable_insts],
+                category_inst=category_inst.copy_shallow(),
+                variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
                 **self.get_plot_parameters(),
             )
 


### PR DESCRIPTION
Within our plotting tasks, `order` objects are copied before being passing to the actual plot functions to avoid in-place changes being made there that would propagate back and lead to unwanted interferences.

However, copies of large interdependent structures (that would be required due to consistency) can result in a significant overhead. For this reason, some `copy()` instructions in order don't always copy the large structures (e.g. nested process trees), but rather forward references over to copied objects. In cases where no other name and/or id is selected, this can result in name or id duplications which in turns raises an error (this behavior is necessary within order).

Our plotting tasks can run into this exact issue as reported in #156. However, I think we can rely on `copy_shallow()` instead, which does exactly the same as `copy()` but does not copy relations to any other object. We should go with this approach and revisit the decision if needed.

Fixes #156.