### PR TITLE
New selector for applying MET filters.

### DIFF
--- a/columnflow/selection/cms/__init__.py
+++ b/columnflow/selection/cms/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+
+"""
+Selector related to MET filters.
+"""
+
+from __future__ import annotations
+
+from columnflow.selection import Selector, selector
+from columnflow.util import maybe_import
+from columnflow.columnar_util import Route
+
+
+ak = maybe_import("awkward")
+
+
+@selector(
+    uses={"event", "nFlag"},
+)
+def met_filters(
+    self: Selector,
+    events: ak.Array,
+    **kwargs,
+) -> ak.Array:
+    """
+    Compute a selection mask to filter out noisy/anomalous high-MET events (MET filters).
+
+    Individual filter decisions based on different criteria are stored as bool-valued columns
+    in the input NanoAOD. The columns to apply are specified via an auxiliary config entry:
+
+    .. code-block:: python
+
+        cfg.x.met_filters = {
+            "Flag.globalSuperTightHalo2016Filter",
+            "Flag.HBHENoiseFilter",
+            "Flag.HBHENoiseIsoFilter",
+            "Flag.EcalDeadCellTriggerPrimitiveFilter",
+            "Flag.BadPFMuonFilter",
+            "Flag.BadPFMuonDzFilter",
+            "Flag.eeBadScFilter",
+            "Flag.ecalBadCalibFilter",
+        }
+
+    The specified columns are interpreted as booleans, with missing values treated as *True*,
+    i.e. the event is considered to have passed the corresponding filter.
+
+    Returns a bool array containing the logical AND of all input columns.
+    """
+    met_filters = set(self.config_inst.x.met_filters)
+
+    result = ak.ones_like(events.event, dtype=bool)
+
+    for route in met_filters:
+        # interpret column values as booleans
+        vals = Route(route).apply(events)
+        vals = ak.values_astype(vals, bool)
+        # treat missing values as a "pass"
+        vals = ak.fill_none(vals, True)
+        # append to the result
+        result = (result & vals)
+
+    return result
+
+
+@met_filters.init
+def met_filters_init(self: Selector) -> None:
+    """
+    Read MET filters from config and add them as input columns.
+    """
+    met_filters = set(self.config_inst.x.met_filters)
+    self.uses |= met_filters


### PR DESCRIPTION
This PR adds a selector for applying a configurable subset of MET filters. These are filters designed to reject noisy events with typically large anomalous MET contributions (from detector noise, beam halo effects, etc.). The filter decisions are pre-computed and stored NanoAOD files as part of the `Flag` table.

Since many analyses apply MET filters, it would be good to have something like this centrally provided in `columnflow`.