### PR TITLE
Make config entry access in producers/calibrators/selectors configurable.

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -110,9 +110,9 @@ def ak_evaluate(evaluator, *args):
     # toggle for propagation to MET
     propagate_met=True,
     # function to determine the correction file
-    get_jec_file=(lambda external_files: external_files.jet_jerc),
+    get_jec_file=(lambda self, external_files: external_files.jet_jerc),
     # function to determine the jec configuration dict
-    get_jec_config=(lambda config_inst: config_inst.x.jec),
+    get_jec_config=(lambda self: self.config_inst.x.jec),
 )
 def jec(
     self: Calibrator,
@@ -304,11 +304,11 @@ def jec_init(self: Calibrator) -> None:
     """
     Add JEC uncertainty shifts to the list of produced columns.
     """
-    jec = self.get_jec_config(self.config_inst)
+    jec_cfg = self.get_jec_config()
 
     sources = self.uncertainty_sources
     if sources is None:
-        sources = jec.uncertainty_sources
+        sources = jec_cfg.uncertainty_sources
 
     # add shifted jet variables
     self.produces |= {
@@ -352,9 +352,9 @@ def jec_setup(self: Calibrator, reqs: dict, inputs: dict) -> None:
     )
 
     # compute JEC keys from config information
-    jec = self.get_jec_config(self.config_inst)
+    jec_cfg = self.get_jec_config()
 
-    def make_jme_keys(names, jec=jec, is_data=self.dataset_inst.is_data):
+    def make_jme_keys(names, jec=jec_cfg, is_data=self.dataset_inst.is_data):
         if is_data:
             jec_era = self.dataset_inst.get_aux("jec_era", None)
             # if no special JEC era is specified, infer based on 'era'
@@ -371,10 +371,10 @@ def jec_setup(self: Calibrator, reqs: dict, inputs: dict) -> None:
     # take sources from constructor or config
     sources = self.uncertainty_sources
     if sources is None:
-        sources = jec.uncertainty_sources
+        sources = jec_cfg.uncertainty_sources
 
-    jec_keys = make_jme_keys(jec.levels)
-    jec_keys_subset_type1_met = make_jme_keys(jec.levels_for_type1_met)
+    jec_keys = make_jme_keys(jec_cfg.levels)
+    jec_keys_subset_type1_met = make_jme_keys(jec_cfg.levels_for_type1_met)
     junc_keys = make_jme_keys(sources, is_data=False)  # uncertainties only stored as MC keys
 
     # store the evaluators
@@ -413,9 +413,9 @@ jec_nominal = jec.derive("jec_nominal", cls_dict={"uncertainty_sources": []})
     # only run on mc
     mc_only=True,
     # function to determine the correction file
-    get_jer_file=(lambda external_files: external_files.jet_jerc),
+    get_jer_file=(lambda self, external_files: external_files.jet_jerc),
     # function to determine the jer configuration dict
-    get_jer_config=(lambda config_inst: config_inst.x.jer),
+    get_jer_config=(lambda self: self.config_inst.x.jer),
 )
 def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -656,10 +656,10 @@ def jer_setup(self: Calibrator, reqs: dict, inputs: dict) -> None:
     )
 
     # compute JER keys from config information
-    jer = self.get_jer_config(self.config_inst)
+    jer_cfg = self.get_jer_config()
     jer_keys = {
-        "jer": f"{jer.campaign}_{jer.version}_MC_PtResolution_{jer.jet_type}",
-        "sf": f"{jer.campaign}_{jer.version}_MC_ScaleFactor_{jer.jet_type}",
+        "jer": f"{jer_cfg.campaign}_{jer_cfg.version}_MC_PtResolution_{jer_cfg.jet_type}",
+        "sf": f"{jer_cfg.campaign}_{jer_cfg.version}_MC_ScaleFactor_{jer_cfg.jet_type}",
     }
 
     # store the evaluators

--- a/columnflow/calibration/cms/met.py
+++ b/columnflow/calibration/cms/met.py
@@ -17,9 +17,9 @@ ak = maybe_import("awkward")
     uses={"run", "PV.npvs", "MET.pt", "MET.phi"},
     produces={"MET.pt", "MET.phi"},
     # function to determine the correction file
-    get_met_file=(lambda external_files: external_files.met_phi_corr),
+    get_met_file=(lambda self, external_files: external_files.met_phi_corr),
     # function to determine met correction config
-    get_met_config=(lambda config_inst: config_inst.x.met_phi_correction_set),
+    get_met_config=(lambda self: self.config_inst.x.met_phi_correction_set),
 )
 def met_phi(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -78,7 +78,7 @@ def met_phi_setup(self: Calibrator, reqs: dict, inputs: dict) -> None:
     correction_set = correctionlib.CorrectionSet.from_string(
         self.get_met_file(bundle.files).load(formatter="gzip").decode("utf-8"),
     )
-    name_tmpl = self.get_met_correction_set(self.config_inst)
+    name_tmpl = self.get_met_config()
     self.met_pt_corrector = correction_set[name_tmpl.format(
         variable="pt",
         data_source=self.dataset_inst.data_source,

--- a/columnflow/calibration/cms/met.py
+++ b/columnflow/calibration/cms/met.py
@@ -16,23 +16,34 @@ ak = maybe_import("awkward")
 @calibrator(
     uses={"run", "PV.npvs", "MET.pt", "MET.phi"},
     produces={"MET.pt", "MET.phi"},
+    # function to determine the correction file
+    get_met_file=(lambda external_files: external_files.met_phi_corr),
+    # function to determine met correction config
+    get_met_config=(lambda config_inst: config_inst.x.met_phi_correction_set),
 )
 def met_phi(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     """
     Performs the MET phi (type II) correction using the correctionlib. Requires an external file in
-    the config as (e.g.)
+    the config under ``met_phi_corr``:
 
     .. code-block:: python
 
-        "met_phi_corr": ("/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-f018adfb/POG/JME/2017_UL/met.json.gz", "v1")  # noqa
+        cfg.x.external_files = DotDict.wrap({
+            "met_phi_corr": "/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-f018adfb/POG/JME/2017_UL/met.json.gz",  # noqa
+        })
 
-    as well as an auxiliary entry in the config to refer to the name of the correction set such as
+    *get_met_file* can be adapted in a subclass in case it is stored differently in the external
+    files.
+
+    The name of the correction set should be present as an auxiliary entry in the config:
 
     .. code-block:: python
 
         cfg.x.met_phi_correction_set = "{variable}_metphicorr_pfmet_{data_source}"
 
     where "variable" and "data_source" are placeholders that are inserted in the calibrator setup.
+    *get_met_correction_set* can be adapted in a subclass in case it is stored differently in the
+    config.
     """
     args = (
         events.MET.pt,
@@ -65,13 +76,14 @@ def met_phi_setup(self: Calibrator, reqs: dict, inputs: dict) -> None:
     # create the pt and phi correctors
     import correctionlib
     correction_set = correctionlib.CorrectionSet.from_string(
-        bundle.files.met_phi_corr.load(formatter="gzip").decode("utf-8"),
+        self.get_met_file(bundle.files).load(formatter="gzip").decode("utf-8"),
     )
-    self.met_pt_corrector = correction_set[self.config_inst.x.met_phi_correction_set.format(
+    name_tmpl = self.get_met_correction_set(self.config_inst)
+    self.met_pt_corrector = correction_set[name_tmpl.format(
         variable="pt",
         data_source=self.dataset_inst.data_source,
     )]
-    self.met_phi_corrector = correction_set[self.config_inst.x.met_phi_correction_set.format(
+    self.met_phi_corrector = correction_set[name_tmpl.format(
         variable="phi",
         data_source=self.dataset_inst.data_source,
     )]

--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -22,9 +22,9 @@ ak = maybe_import("awkward")
     # only run on mc
     mc_only=True,
     # function to determine the correction file
-    get_btag_file=(lambda external_files: external_files.btag_sf_corr),
+    get_btag_file=(lambda self, external_files: external_files.btag_sf_corr),
     # function to determine the muon weight config
-    get_btag_config=(lambda config_inst: config_inst.x.btag_sf),
+    get_btag_config=(lambda self: self.config_inst.x.btag_sf),
 )
 def btag_weights(
     self: Producer,
@@ -151,7 +151,7 @@ def btag_weights_init(self: Producer) -> None:
     btag_sf_jec_source = "" if self.jec_source == "Total" else self.jec_source
     self.shift_is_known_jec_source = (
         self.jec_source and
-        btag_sf_jec_source in self.get_btag_config(self.config_inst)[1]
+        btag_sf_jec_source in self.get_btag_config()[1]
     )
 
     # save names of method-intrinsic uncertainties
@@ -202,5 +202,5 @@ def btag_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
     correction_set = correctionlib.CorrectionSet.from_string(
         self.get_btag_file(bundle.files).load(formatter="gzip").decode("utf-8"),
     )
-    corrector_name = self.get_btag_config(self.config_inst)[0]
+    corrector_name = self.get_btag_config()[0]
     self.btag_sf_corrector = correction_set[corrector_name]

--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -25,9 +25,9 @@ ak = maybe_import("awkward")
     # only run on mc
     mc_only=True,
     # function to determine the correction file
-    get_electron_file=(lambda external_files: external_files.eletron_sf),
+    get_electron_file=(lambda self, external_files: external_files.electron_sf),
     # function to determine the electron weight config
-    get_electron_config=(lambda config_inst: config_inst.x.electron_sf_names),
+    get_electron_config=(lambda self: self.config_inst.x.electron_sf_names),
 )
 def electron_weights(
     self: Producer,
@@ -107,5 +107,5 @@ def electron_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
     correction_set = correctionlib.CorrectionSet.from_string(
         self.get_electron_file(bundle.files).load(formatter="gzip").decode("utf-8"),
     )
-    corrector_name, self.year, self.wp = self.get_electron_config(self.config_inst)
+    corrector_name, self.year, self.wp = self.get_electron_config()
     self.electron_sf_corrector = correction_set[corrector_name]

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -25,9 +25,9 @@ ak = maybe_import("awkward")
     # only run on mc
     mc_only=True,
     # function to determine the correction file
-    get_muon_file=(lambda external_files: external_files.muon_sf),
+    get_muon_file=(lambda self, external_files: external_files.muon_sf),
     # function to determine the muon weight config
-    get_muon_config=(lambda config_inst: config_inst.x.muon_sf_names),
+    get_muon_config=(lambda self: self.config_inst.x.muon_sf_names),
 )
 def muon_weights(
     self: Producer,
@@ -103,5 +103,5 @@ def muon_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
     correction_set = correctionlib.CorrectionSet.from_string(
         self.get_muon_file(bundle.files).load(formatter="gzip").decode("utf-8"),
     )
-    corrector_name, self.year = self.get_muon_config(self.config_inst)
+    corrector_name, self.year = self.get_muon_config()
     self.muon_sf_corrector = correction_set[corrector_name]

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -19,7 +19,7 @@ maybe_import("scipy.sparse")
 @selector(
     uses={"run", "luminosityBlock"},
     # function to determine the golden lumi file
-    get_lumi_file=(lambda external_files: external_files.lumi.golden),
+    get_lumi_file=(lambda self, external_files: external_files.lumi.golden),
 )
 def json_filter(
     self: Selector,

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -18,6 +18,8 @@ maybe_import("scipy.sparse")
 
 @selector(
     uses={"run", "luminosityBlock"},
+    # function to determine the golden lumi file
+    get_lumi_file=(lambda external_files: external_files.lumi.golden),
 )
 def json_filter(
     self: Selector,
@@ -26,17 +28,22 @@ def json_filter(
     **kwargs,
 ) -> ak.Array:
     """
-    Select only events from certified luminosity blocks included in the "golden" JSON. This filter can only be applied in recorded data.
+    Select only events from certified luminosity blocks included in the "golden" JSON. This filter
+    can only be applied in recorded data.
 
-    The JSON file must specified in the config as an external file under "lumi.golden":
+    By default, the JSON file should specified in the config as an external file under
+    ``lumi.golden``:
 
     .. code-block:: python
 
         cfg.x.external_files = DotDict.wrap({
             "lumi": {
-                "golden": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt"  # noqa
+                "golden": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",  # noqa
             },
         })
+
+    *get_lumi_file* can be adapted in a subclass in case it is stored differently in the external
+    files.
     """
     lookup_result = self.run_ls_lookup[events.run, events.luminosityBlock].todense()
     return np.squeeze(np.array(lookup_result))
@@ -62,7 +69,7 @@ def json_filter_setup(self: Selector, reqs: dict, inputs: dict) -> None:
     bundle = reqs["external_files"]
 
     # import the correction sets from the external file
-    json = bundle.files.lumi.golden.load(formatter="json")
+    json = self.get_lumi_file(bundle.files).load(formatter="json")
 
     # determine range of run/luminosity block values
     max_ls = max(ls for ls_ranges in json.values() for ls in ak.ravel(ls_ranges))

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -17,7 +17,7 @@ ak = maybe_import("awkward")
 @selector(
     uses={"event", "nFlag"},
     # function to obtain met filters from the config
-    get_met_filters=(lambda config_inst: config_inst.x.met_filters),
+    get_met_filters=(lambda self: self.config_inst.x.met_filters),
 )
 def met_filters(
     self: Selector,
@@ -70,7 +70,7 @@ def met_filters_init(self: Selector) -> None:
     """
     Read MET filters from config and add them as input columns.
     """
-    met_filters = self.get_met_filters(self.config_inst)
+    met_filters = self.get_met_filters()
     if isinstance(met_filters, dict):
         # do nothing when no dataset_inst is known
         if not getattr(self, "dataset_inst", None):

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -16,6 +16,8 @@ ak = maybe_import("awkward")
 
 @selector(
     uses={"event", "nFlag"},
+    # function to obtain met filters from the config
+    get_met_filters=(lambda config_inst: config_inst.x.met_filters),
 )
 def met_filters(
     self: Selector,
@@ -41,6 +43,9 @@ def met_filters(
             "Flag.ecalBadCalibFilter",
         }
 
+    *get_met_filters* can be adapted in a subclass in case they are stored differently in the
+    config.
+
     The specified columns are interpreted as booleans, with missing values treated as *True*,
     i.e. the event is considered to have passed the corresponding filter.
 
@@ -65,7 +70,7 @@ def met_filters_init(self: Selector) -> None:
     """
     Read MET filters from config and add them as input columns.
     """
-    met_filters = self.config_inst.x.met_filters
+    met_filters = self.get_met_filters(self.config_inst)
     if isinstance(met_filters, dict):
         # do nothing when no dataset_inst is known
         if not getattr(self, "dataset_inst", None):


### PR DESCRIPTION
This PR generalizes our common producers, selectors and calibrators that require certain entries either in the config or in external files. So far, we documented how the config / file entries are accessed, and the config itself was essentially enforced to follow that structure.

However, in some standard scenarios, this might not be flexible enough. For instance, in case one quickly wants to compare the influence of new - say - btag scale factors, one would have to toggle the config entry and run things with that temporary change, usually under a different version.

This PR allows for a more flexible definition by using simple configurable helper functions that can be overwritten.

```python
new_btag_weights = btag_weights.derive(
    cls_name="new_btag_weights",
    cls_dict={
        "get_btag_file": (lambda external_files: external_files.new_btag_sf),
    },
)
```

In this case, `get_btag_file` overwrites its default implementation, which would result in the usual location in the external files. Now,

```
law run SOMETASK --producer btag_weights ...
```

and

```
law run SOMETASK --producer new_btag_weights ...
```

could be run in parallel without the need to toggle things in the config.