### PR TITLE
Fix empty setup mode for remote jobs.

### DIFF
--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -77,8 +77,8 @@ setup_venv() {
         >&2 echo "unknown venv setup mode '${mode}'"
         return "1"
     fi
-    if [ "${CF_REMOTE_JOB}" = "1" ] && [ ! -z "${mode}" ]; then
-        >&2 echo "the venv setup mode must be empty in remote jobs, but got '${mode}'"
+    if [ "${CF_REMOTE_JOB}" = "1" ] && [ "${mode}" != "install" ]; then
+        >&2 echo "the venv setup mode must be 'install' or empty in remote jobs, but got '${mode}'"
         return "2"
     fi
     if [ "${versioncheck}" != "yes" ] && [ "${versioncheck}" != "no" ] && [ "${versioncheck}" != "silent" ] && [ "${versioncheck}" != "warn" ]; then


### PR DESCRIPTION
This PR proposes a fix for the install mode check for remote jobs. Following the changes introduced by [`75f013`](https://github.com/uhh-cms/columnflow/commit/75f0136527ece4fcb4ec5d6001ea039b17744cea), the empty `mode` is being resolved before checking if it is empty for remote jobs, which always leads to an error.