### PR TITLE
Update default chunk size

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -43,8 +43,8 @@ slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
 
 # ChunkedIOHandler defaults
-chunked_io_chunk_size: 50000
-chunked_io_pool_size: 4
+chunked_io_chunk_size: 100000
+chunked_io_pool_size: 2
 chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be

--- a/law.cfg
+++ b/law.cfg
@@ -38,8 +38,8 @@ slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
 
 # ChunkedIOHandler defaults
-chunked_io_chunk_size: 50000
-chunked_io_pool_size: 4
+chunked_io_chunk_size: 100000
+chunked_io_pool_size: 2
 chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be


### PR DESCRIPTION
This PR updates the default chunk size used for our parallel array reader from 50k to 100k. Also, the default number of used threads is reduced from 4 to 2.

I did a couple lightweight IO studies to check which combination results in the best overall performance (done on a large ttbar file with 26 chunks, all times are stated as sums over all chunks):

|        Type        | Processing [s] | IO [s] |
| ------------------ | -------------- | ------ |
| 0 IO threads, 50k  |            147 |     53 |
| 1 IO thread, 50k   |            147 |     32 |
| 2 IO threads, 50k  |            151 |     23 |
| 4 IO threads, 50k  |            149 |     24 |
| ------------------ | -------------- | ------ |
| 0 IO threads, 100k |            117 |     41 |
| 1 IO thread, 100k  |            120 |     26 |
| 2 IO threads, 100k |            119 |     17 |
| 4 IO threads, 100k |            117 |     17 |

The processing time (second column) of the same events with a larger chunk size (== fewer chunks) seems favorable up to about 100-150k. **However**, for higher values the memory consumption gains relevance and we should probably not go higher than that (at least not for the default setting).

The IO (read) time is also clearly improved when loading larger chunks (== less often).

This is not a definitive final result, and the best option will always depend on the actual processing payload, but for now this seemed like some low hanging fruits.

It should be noted that once changed, existing intermediate files would need to be re-processed.