### PR TITLE
Ensure unique sandbox install paths.

### DIFF
--- a/analysis_templates/cms_minimal/sandboxes/example.sh
+++ b/analysis_templates/cms_minimal/sandboxes/example.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/example.txt"
 

--- a/analysis_templates/cms_minimal/sandboxes/example_dev.sh
+++ b/analysis_templates/cms_minimal/sandboxes/example_dev.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/example.txt,${CF_BASE}/requirements_dev.txt"
 

--- a/bin/cf_sandbox_file_hash
+++ b/bin/cf_sandbox_file_hash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+action() {
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
+    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+
+    python "${this_dir}/$( basename "${this_file}" ).py" "$@"
+}
+action "$@"

--- a/bin/cf_sandbox_file_hash.py
+++ b/bin/cf_sandbox_file_hash.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Standalone script that takes the path to a sandbox file and returns a unique hash based on its path
+relative to certain environment variables.
+
+- If it is found to be relative to CF_REPO_BASE, the path to hash will relative to $CF_REPO_BASE. In
+  case an alias is defined (usually by an upstream analysis repository), this alias is used instead.
+- If it is found to be relative to CF_BASE, the path will be relative to $CF_BASE.
+- In case none of the above applies, the requestd path is used unchanged.
+
+
+Example 1:
+
+> cf_sandbox_file_hash /path/to/cf/sandboxes/venv_columnar.sh
+> 4ef45674
+
+The above creates the hash for $CF_BASE/sandboxes/venv_columnar.sh since CF_BASE is identical to
+/path/to/cf.
+
+
+Example 2:
+
+> cf_sandbox_file_hash /path/to/my_analysis/sandboxes/venv_columnar.sh
+> 7e853f05
+
+The above creates the hash for $CF_REPO_BASE/sandboxes/venv_columnar.sh if CF_REPO_BASE_ALIAS is
+_not_ set.
+
+
+Example 3:
+
+> cf_sandbox_file_hash /path/to/my_analysis/sandboxes/venv_columnar.sh
+> 76463f9e
+
+The above creates the hash for $MY_ANALYSIS_BASE/sandboxes/venv_columnar.sh if
+CF_REPO_BASE_ALIAS=MY_ANALYSIS_BASE.
+"""
+
+import os
+import hashlib
+
+
+def create_sandbox_file_hash(sandbox_file: str, return_path: bool = False) -> str:
+    """
+    Creates a hash of a *sandbox_file*, relative to either CF_REPO_BASE if set, or CF_BASE
+    otherwise. When it is found to be relative to CF_REPO_BASE and a CF_REPO_BASE_ALIAS is defined,
+    CF_REPO_BASE_ALIAS is used instead.
+
+    The hash itself is based on the first eight characters of the sha1sum of the relative sandbox
+    file.
+
+    If *return_path* is *True*, this function does not return the hash but rather the path
+    determined by the mechanism above.
+    """
+    # prepare paths
+    abs_sandbox_file = real_path(sandbox_file)
+    cf_repo_base = real_path(os.environ["CF_REPO_BASE"])
+    cf_base = real_path(os.environ["CF_BASE"])
+
+    # determine the base paths
+    rel_to_repo_base = is_relative_to(abs_sandbox_file, cf_repo_base)
+    rel_to_base = is_relative_to(abs_sandbox_file, cf_base)
+
+    # relative to CF_BASE or CF_REPO_BASE?
+    if rel_to_base:
+        path_to_hash = os.path.join("$CF_BASE", os.path.relpath(abs_sandbox_file, cf_base))
+    elif rel_to_repo_base:
+        # use the CF_REPO_BASE variable as the base path, optionally replaced by an alias
+        base = os.getenv("CF_REPO_BASE_ALIAS", "CF_REPO_BASE")
+        path_to_hash = os.path.join(f"${base}", os.path.relpath(abs_sandbox_file, cf_repo_base))
+    else:
+        # use the file as is
+        path_to_hash = sandbox_file
+
+    if return_path:
+        return path_to_hash
+
+    return hashlib.sha1(path_to_hash.encode("utf-8")).hexdigest()[:8]
+
+
+def real_path(*path: str) -> str:
+    """
+    Takes *path* fragments and returns the real, absolute location with all variables expanded.
+    """
+    path = os.path.join(*map(str, path))
+    while "$" in path or "~" in path:
+        path = os.path.expandvars(os.path.expanduser(path))
+
+    return os.path.realpath(path)
+
+
+def is_relative_to(path: str, base: str) -> bool:
+    """
+    Returns *True* if a *path* is contained at any depth inside a *base* path, and *False*
+    otherwise.
+    """
+    return not os.path.relpath(real_path(path), real_path(base)).startswith("..")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="creates a hash of a sandbox file",
+    )
+    parser.add_argument(
+        "sandbox_file",
+        help="the sandbox file",
+    )
+    parser.add_argument(
+        "--path",
+        "-p",
+        action="store_true",
+        help="print the path determined for hashing rather than the hash itself",
+    )
+    args = parser.parse_args()
+
+    print(create_sandbox_file_hash(args.sandbox_file, return_path=args.path))

--- a/bin/cf_sandbox_file_hash.py
+++ b/bin/cf_sandbox_file_hash.py
@@ -5,10 +5,11 @@
 Standalone script that takes the path to a sandbox file and returns a unique hash based on its path
 relative to certain environment variables.
 
-- If it is found to be relative to CF_REPO_BASE, the path to hash will relative to $CF_REPO_BASE. In
-  case an alias is defined (usually by an upstream analysis repository), this alias is used instead.
 - If it is found to be relative to CF_BASE, the path will be relative to $CF_BASE.
-- In case none of the above applies, the requestd path is used unchanged.
+- If it is found to be relative to CF_REPO_BASE, the path to hash will be relative to $CF_REPO_BASE.
+  In case an alias is defined (usually by an upstream analysis repository), this alias is used
+  instead.
+- If none of the above applies, the requestd path is used unchanged.
 
 
 Example 1:

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -167,8 +167,7 @@ def expand_path(*path: str) -> str:
 
 def real_path(*path: str) -> str:
     """
-    Takes *path* fragments and returns the joined,  real and absolute location with all variables
-    expanded.
+    Takes *path* fragments and returns the real, absolute location with all variables expanded.
     """
     return os.path.realpath(expand_path(*path))
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,5 +16,5 @@ six~=1.16
 # sandbox packages
 awkward~=2.0
 uproot~=5.0
-git+https://github.com/CoffeaTeam/coffea.git@36fa8ac#egg=coffea
+git+https://github.com/riga/coffea.git@9ecdee5#egg=coffea
 dask-awkward~=2023.2

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -4,7 +4,11 @@
 # the venv is already present, and whether the script is called as part of a remote (law) job
 # (CF_REMOTE_JOB=1).
 #
-# Three environment variables are expected to be set before this script is called:
+# Four environment variables are expected to be set before this script is called:
+#   CF_SANDBOX_FILE
+#       The path of the file that contained the sandbox definition and that sourced _this_ script.
+#       It is used to derive a hash for defining the installation directory and to set the value of
+#       the LAW_SANDBOX variable.
 #   CF_VENV_BASE
 #       The base directory where virtual environments will be installed. Set by the main setup.sh.
 #   CF_VENV_NAME
@@ -17,19 +21,20 @@
 #   CF_DEV
 #       Set to "1" when CF_VENV_NAME ends with "_dev", and "0" otherwise.
 #   LAW_SANDBOX
-#       Set to the name of the sandbox to be correctly interpreted later on by law.
+#       Set to the name of the sandbox to be correctly interpreted later on by law. See
+#       CF_SANDBOX_FILE above.
 #
 # Optional arguments:
-# 1. mode
+#   1. mode
 #      The setup mode. Different values are accepted:
-#        - ''/install:  The virtual environment is installed when not existing yet and sourced.
-#        - reinstall:   The virtual environment is removed first, then reinstalled and sourced.
-#        - update:      The virtual environment is removed first in case it is outdated, then
-#                       reinstalled and sourced.
-#      Please note that if the mode is empty ('') and the environment variable CF_VENV_SETUP_MODE is
-#      defined, its value is used instead.
+#        - ''/install: The virtual environment is installed when not existing yet and sourced.
+#        - reinstall:  The virtual environment is removed first, then reinstalled and sourced.
+#        - update:     The virtual environment is removed first in case it is outdated, then
+#                      reinstalled and sourced.
+#      Please note that if the mode is empty ('') and the environment variable CF_SANDBOX_SETUP_MODE
+#      is defined, its value is used instead.
 #
-# 2. versioncheck
+#   2. versioncheck
 #      When "yes", perform a version check, print a warning in case of a mismatch and set a specific
 #      exit code (21). When "no", the check is skipped alltogether. When "silent", no warning is
 #      printed but an exit code might be set. When "warn" (the default), a warning might be printed,
@@ -65,8 +70,8 @@ setup_venv() {
 
     # default mode
     if [ -z "${mode}" ]; then
-        if [ ! -z "${CF_VENV_SETUP_MODE}" ]; then
-            mode="${CF_VENV_SETUP_MODE}"
+        if [ ! -z "${CF_SANDBOX_SETUP_MODE}" ]; then
+            mode="${CF_SANDBOX_SETUP_MODE}"
         else
             mode="install"
         fi
@@ -91,13 +96,19 @@ setup_venv() {
     # check required global variables
     #
 
+    local sandbox_file="${CF_SANDBOX_FILE}"
+    unset CF_SANDBOX_FILE
+    if [ -z "${sandbox_file}" ]; then
+        >&2 echo "CF_SANDBOX_FILE is not set but required by ${this_file}"
+        return "10"
+    fi
     if [ -z "${CF_VENV_NAME}" ]; then
         >&2 echo "CF_VENV_NAME is not set but required by ${this_file}"
-        return "5"
+        return "11"
     fi
     if [ -z "${CF_VENV_REQUIREMENTS}" ]; then
         >&2 echo "CF_VENV_REQUIREMENTS is not set but required by ${this_file}"
-        return "6"
+        return "12"
     fi
 
     # split $CF_VENV_REQUIREMENTS into an array
@@ -111,7 +122,7 @@ setup_venv() {
     for f in ${requirement_files[@]}; do
         if [ ! -f "${f}" ]; then
             >&2 echo "requirement file '${f}' does not exist"
-            return "7"
+            return "13"
         fi
         if [ "${f}" = "${CF_BASE}/requirements_prod.txt" ]; then
             requirement_files_contains_prod="true"
@@ -124,16 +135,18 @@ setup_venv() {
     # start the setup
     #
 
-    local install_path="${CF_VENV_BASE}/${CF_VENV_NAME}"
-    local install_path_repr="\$CF_VENV_BASE/${CF_VENV_NAME}"
+    local install_hash="$( cf_sandbox_file_hash "${sandbox_file}" )"
+    local venv_name_hashed="${CF_VENV_NAME}_${install_hash}"
+    local install_path="${CF_VENV_BASE}/${venv_name_hashed}"
+    local install_path_repr="\$CF_VENV_BASE/${venv_name_hashed}"
     local venv_version="$( cat "${first_requirement_file}" | grep -Po "# version \K\d+.*" )"
-    local pending_flag_file="${CF_VENV_BASE}/pending_${CF_VENV_NAME}"
+    local pending_flag_file="${CF_VENV_BASE}/pending_${venv_name_hashed}"
     export CF_SANDBOX_FLAG_FILE="${install_path}/cf_flag"
 
     # the venv version must be set
     if [ -z "${venv_version}" ]; then
         >&2 echo "first requirement file ${first_requirement_file} does not contain a version line"
-        return "8"
+        return "20"
     fi
 
     # ensure the CF_VENV_BASE exists
@@ -169,7 +182,7 @@ setup_venv() {
                 sleep_counter="$(( $sleep_counter + 1 ))"
                 if [ "${sleep_counter}" -ge 120 ]; then
                     >&2 echo "venv ${CF_VENV_NAME} is setup in different process, but number of sleeps exceeded"
-                    return "10"
+                    return "22"
                 fi
                 cf_color yellow "venv ${CF_VENV_NAME} already being setup in different process, sleep ${sleep_counter} / 120"
                 sleep 10
@@ -178,20 +191,23 @@ setup_venv() {
 
         # create the pending_flag to express that the venv state might be changing
         touch "${pending_flag_file}"
+        clear_pending() {
+            rm -f "${pending_flag_file}"
+        }
 
         # checks to be performed if the venv already exists
         if [ -f "${CF_SANDBOX_FLAG_FILE}" ]; then
             # get the current version
-            local curr_version="$( cat "${CF_SANDBOX_FLAG_FILE}" | grep -Po "version \K\d+.*" )"
-            if [ -z "${curr_version}" ]; then
+            local current_version="$( cat "${CF_SANDBOX_FLAG_FILE}" | grep -Po "version \K\d+.*" )"
+            if [ -z "${current_version}" ]; then
                 >&2 echo "the flag file ${CF_SANDBOX_FLAG_FILE} does not contain a valid version"
-                return "20"
+                return "23"
             fi
 
-            if [ "${curr_version}" != "${venv_version}" ]; then
+            if [ "${current_version}" != "${venv_version}" ]; then
                 if [ "${mode}" = "update" ]; then
                     # remove the venv in case an update is requested
-                    echo "removing current installation at ${install_path_repr} (mode '${mode}', installed version ${curr_version}, requested version ${venv_version})"
+                    echo "removing current installation at ${install_path_repr} (mode '${mode}', installed version ${current_version}, requested version ${venv_version})"
                     rm -rf "${install_path}"
 
                 elif [ "${versioncheck}" != "no" ]; then
@@ -200,12 +216,13 @@ setup_venv() {
                         ret="21"
                     fi
                     if [ "${versioncheck}" != "silent" ]; then
-                        >&2 echo ""
-                        >&2 echo "WARNING: outdated venv '${CF_VENV_NAME}' (installed version ${curr_version}, requested version ${venv_version}) located at"
-                        >&2 echo "WARNING: ${install_path_repr}"
+                        >&2 echo
+                        >&2 echo "WARNING: outdated venv '${venv_name_hashed}'"
+                        >&2 echo "WARNING: (installed version ${current_version}, requested version ${venv_version})"
+                        >&2 echo "WARNING: located at ${install_path_repr}"
                         >&2 echo "WARNING: please consider updating it by adding 'update' to the source command"
-                        >&2 echo "WARNING: or by setting the environment variable 'CF_VENV_SETUP_MODE=update'"
-                        >&2 echo ""
+                        >&2 echo "WARNING: or by setting the environment variable 'CF_SANDBOX_SETUP_MODE=update'"
+                        >&2 echo
                     fi
                 fi
             fi
@@ -218,39 +235,39 @@ setup_venv() {
 
         # install if not existing
         if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
-            cf_color cyan "installing venv at ${install_path}"
+            cf_color cyan "installing venv at ${install_path} from ${sandbox_file}"
 
             rm -rf "${install_path}"
-            cf_create_venv "${CF_VENV_NAME}"
-            [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "11"
+            cf_create_venv "${venv_name_hashed}"
+            [ "$?" != "0" ] && clear_pending && return "25"
 
             # activate it
             source "${install_path}/bin/activate" ""
-            [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "12"
+            [ "$?" != "0" ] && clear_pending && return "26"
 
             # update pip
             cf_color magenta "updating pip"
             python -m pip install -U pip
-            [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "13"
+            [ "$?" != "0" ] && clear_pending && return "27"
 
             # install basic production requirements
             if ! ${requirement_files_contains_prod}; then
                 cf_color magenta "installing requirement file ${CF_BASE}/requirements_prod.txt"
                 python -m pip install -r "${CF_BASE}/requirements_prod.txt"
-                [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "14"
+                [ "$?" != "0" ] && clear_pending && return "28"
             fi
 
             # install requirement files
             for f in ${requirement_files[@]}; do
                 cf_color magenta "installing requirement file ${f}"
                 python -m pip install -r "${f}"
-                [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "16"
+                [ "$?" != "0" ] && clear_pending && return "29"
                 echo
             done
 
             # ensure that the venv is relocateable
-            cf_make_venv_relocateable "${CF_VENV_NAME}"
-            [ "$?" != "0" ] && rm -f "${pending_flag_file}" && return "16"
+            cf_make_venv_relocateable "${venv_name_hashed}"
+            [ "$?" != "0" ] && clear_pending && return "30"
 
             # write the version and a timestamp into the flag file
             echo "version ${venv_version}" > "${CF_SANDBOX_FLAG_FILE}"
@@ -258,7 +275,7 @@ setup_venv() {
         fi
 
         # remove the pending_flag
-        rm -f "${pending_flag_file}"
+        clear_pending
     fi
 
     # handle remote job environments
@@ -287,7 +304,7 @@ setup_venv() {
             done
             if ! ${found_sandbox}; then
                 >&2 echo "bash sandbox ${CF_VENV_BASE} not found in job configuration, stopping"
-                return "30"
+                return "31"
             fi
         fi
 
@@ -298,6 +315,8 @@ setup_venv() {
 
     # export variables
     export CF_VENV_NAME="${CF_VENV_NAME}"
+    export CF_VENV_HASH="${install_hash}"
+    export CF_VENV_NAME_HASHED="${venv_name_hashed}"
     export CF_DEV="$( [[ "${CF_VENV_NAME}" == *_dev ]] && echo "1" || echo "0" )"
 
     # prepend persistent path fragments again for ensure priority for local packages
@@ -305,7 +324,7 @@ setup_venv() {
     export PYTHONPATH="${CF_PERSISTENT_PYTHONPATH}:${PYTHONPATH}"
 
     # mark this as a bash sandbox for law
-    export LAW_SANDBOX="bash::\$CF_BASE/sandboxes/${CF_VENV_NAME}.sh"
+    export LAW_SANDBOX="bash::$( cf_sandbox_file_hash -p "${sandbox_file}" )"
 
     return "${ret}"
 }

--- a/sandboxes/cf_dev.sh
+++ b/sandboxes/cf_dev.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${CF_BASE}/requirements_dev.txt,${CF_BASE}/requirements_prod.txt"
 

--- a/sandboxes/cf_prod.sh
+++ b/sandboxes/cf_prod.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${CF_BASE}/requirements_prod.txt"
 

--- a/sandboxes/cmssw_default.sh
+++ b/sandboxes/cmssw_default.sh
@@ -12,6 +12,7 @@ action() {
     local os_version="$( cat /etc/os-release | grep VERSION_ID | sed -E 's/VERSION_ID="([0-9]+)"/\1/' )"
 
     # set variables and source the generic CMSSW setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_SCRAM_ARCH="$( [ "${os_version}" = "8" ] && echo "el8" || echo "slc7" )_amd64_gcc10"
     export CF_CMSSW_VERSION="CMSSW_12_6_2"
     export CF_CMSSW_ENV_NAME="$( basename "${this_file%.sh}" )"

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -2,7 +2,7 @@
 
 awkward~=2.0
 uproot~=5.0
-git+https://github.com/CoffeaTeam/coffea.git@36fa8ac#egg=coffea
+git+https://github.com/riga/coffea.git@9ecdee5#egg=coffea
 dask-awkward~=2023.2
 correctionlib~=2.2
 tabulate~=0.9

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,7 +1,7 @@
 # version 5
 
 awkward~=2.0
-git+https://github.com/CoffeaTeam/coffea.git@36fa8ac#egg=coffea
+git+https://github.com/riga/coffea.git@9ecdee5#egg=coffea
 dask-awkward~=2023.2
 tabulate~=0.9
 zstandard~=0.20

--- a/sandboxes/venv_columnar.sh
+++ b/sandboxes/venv_columnar.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/columnar.txt"
 

--- a/sandboxes/venv_columnar_dev.sh
+++ b/sandboxes/venv_columnar_dev.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/columnar.txt,${CF_BASE}/requirements_dev.txt"
 

--- a/sandboxes/venv_docs_dev.sh
+++ b/sandboxes/venv_docs_dev.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${CF_BASE}/docs/requirements.txt"
 

--- a/sandboxes/venv_ml_tf.sh
+++ b/sandboxes/venv_ml_tf.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/ml_tf.txt"
 

--- a/sandboxes/venv_ml_tf_dev.sh
+++ b/sandboxes/venv_ml_tf_dev.sh
@@ -9,6 +9,7 @@ action() {
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
     # set variables and source the generic venv setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
     export CF_VENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_VENV_REQUIREMENTS="${this_dir}/ml_tf.txt,${CF_BASE}/requirements_dev.txt"
 

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,12 @@ setup_columnflow() {
     #       Queried during the interactive setup.
     #   CF_REPO_BASE
     #       The base path of the main repository invoking tasks or scripts. Used by columnflow tasks
-    #       to identify the repository for e.g. bundling. Set to $CF_BASE when not defined already.
+    #       to identify the repository that is bundled into remote jobs. Set to $CF_BASE when not
+    #       defined already.
+    #   CF_REPO_BASE_ALIAS
+    #       Name of an environment variable whose value is identical to that of CF_REPO_BASE and
+    #      that is usually used by an upstream analysis. For instance, if the analysis base is
+    #      stored in "$MY_ANALYSIS_BASE", CF_REPO_BASE_ALIAS should be "MY_ANALYSIS_BASE" (no $).
     #   CF_CONDA_BASE
     #       The directory where conda and conda envs are installed. Might point to
     #       $CF_SOFTWARE_BASE/conda.
@@ -195,6 +200,7 @@ setup_columnflow() {
 
     # continue the fixed setup
     export CF_REPO_BASE="${CF_REPO_BASE:-$CF_BASE}"
+    export CF_REPO_BASE_ALIAS="${CF_REPO_BASE_ALIAS:-}"
     export CF_CONDA_BASE="${CF_CONDA_BASE:-${CF_SOFTWARE_BASE}/conda}"
     export CF_VENV_BASE="${CF_VENV_BASE:-${CF_SOFTWARE_BASE}/venvs}"
     export CF_CMSSW_BASE="${CF_CMSSW_BASE:-${CF_SOFTWARE_BASE}/cmssw}"
@@ -203,6 +209,12 @@ setup_columnflow() {
     export CF_ORIG_PYTHONPATH="${PYTHONPATH}"
     export CF_ORIG_PYTHON3PATH="${PYTHON3PATH}"
     export CF_ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
+
+    # show a warning in case no CF_REPO_BASE_ALIAS is set
+    if [ -z "${CF_REPO_BASE_ALIAS}" ]; then
+        cf_color yellow "the variable CF_REPO_BASE_ALIAS is unset"
+        cf_color yellow "please consider setting it to the name of the variable that refers to your analysis base directory"
+    fi
 
 
     #
@@ -434,7 +446,7 @@ cf_setup_software_stack() {
     # persistent PATH and PYTHONPATH parts that should be
     # priotized over any additions made in sandboxes
     export CF_PERSISTENT_PATH="${CF_BASE}/bin:${CF_BASE}/modules/law/bin:${CF_SOFTWARE_BASE}/bin"
-    export CF_PERSISTENT_PYTHONPATH="${CF_BASE}:${CF_BASE}/modules/law:${CF_BASE}/modules/order"
+    export CF_PERSISTENT_PYTHONPATH="${CF_BASE}:${CF_BASE}/bin:${CF_BASE}/modules/law:${CF_BASE}/modules/order"
 
     # prepend them
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
@@ -498,7 +510,7 @@ EOF
                 cf_color cyan "setting up conda environment"
                 conda install --yes libgcc gfal2 gfal2-util python-gfal2 git git-lfs conda-pack || return "$?"
                 # TODO: temporary issue with numba and numpy
-                conda install --yes "numpy<1.24" || return "$?"
+                # conda install --yes "numpy<1.24" || return "$?"
                 conda clean --yes --all
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack
@@ -518,10 +530,10 @@ EOF
         #
 
         show_version_warning() {
-            >&2 echo ""
+            >&2 echo
             >&2 echo "WARNING: your venv '$1' is not up to date, please consider updating it in a new shell with"
-            >&2 echo "         > CF_REINSTALL_SOFTWARE=1 source setup.sh $( ${setup_is_default} || echo "${setup_name}" )"
-            >&2 echo ""
+            >&2 echo "WARNING: > CF_REINSTALL_SOFTWARE=1 source setup.sh $( ${setup_is_default} || echo "${setup_name}" )"
+            >&2 echo
         }
 
         # source the prod sandbox, potentially skipped in CI jobs
@@ -597,6 +609,7 @@ cf_init_submodule() {
         fi
     fi
 }
+[ ! -z "${BASH_VERSION}" ] && export -f cf_init_submodule
 
 cf_color() {
     local color="$1"
@@ -653,6 +666,7 @@ cf_color() {
             ;;
     esac
 }
+[ ! -z "${BASH_VERSION}" ] && export -f cf_color
 
 main() {
     # Invokes the main action of this script, catches possible error codes and prints a message.

--- a/setup.sh
+++ b/setup.sh
@@ -437,7 +437,7 @@ cf_setup_software_stack() {
     local setup_name="${1}"
     local setup_is_default="false"
     [ "${setup_name}" = "default" ] && setup_is_default="true"
-    local miniconda_source="https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh"
+    local miniconda_source="https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh"
     local pyv="3.9"
 
     # empty the PYTHONPATH
@@ -510,7 +510,7 @@ EOF
                 cf_color cyan "setting up conda environment"
                 conda install --yes libgcc gfal2 gfal2-util python-gfal2 git git-lfs conda-pack || return "$?"
                 # TODO: temporary issue with numba and numpy
-                # conda install --yes "numpy<1.24" || return "$?"
+                conda install --yes "numpy<1.24" || return "$?"
                 conda clean --yes --all
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack


### PR DESCRIPTION
This PR fixes a naming collision between different sandboxes that would currently be installed into the same directory.

Right now, sandboxes are stored e.g. in `$CF_(VENV|CMSSW)_BASE/<sandbox_name>/`, where the `sandbox_name` can be defined by the sandbox itself. However, when there are multiple sandboxes with the same name, the install paths are identical, but they clearly shouldn't.

This PR changes the install paths to `$CF_(VENV|CMSSW)_BASE/<sandbox_name>_<sandbox_hash>/` where the hash is a unique identifier based on the location of the sandbox file. There are two complications that render this PR rather large:

- The shell environment (in which sandboxes are built) and python tools (where bundling for remote jobs takes place) have to agree on the hash definition.
- The hash is based on the sandbox file location, but one can't use the absolute path here. Instead, names of environment variables must be considered (e.g. `\$CF_BASE/sandboxes/venv_columnar.sh` or `\$MY_ANALYSIS_BASE/sandboxes/my_venv.sh`) so that the local env and remote job envs also agree on the same hashes.

Fixes #211.