### PR TITLE
Implementation of CreateYieldTable task

### DIFF
--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -9,7 +9,10 @@ from collections import OrderedDict
 import law
 import luigi
 
-from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin,
+    DatasetsProcessesMixin, CategoriesMixin,
+)
 from columnflow.tasks.framework.remote import RemoteWorkflow
 
 from columnflow.tasks.histograms import MergeHistograms
@@ -18,7 +21,11 @@ from columnflow.util import dev_sandbox
 
 class CreateYieldTable(
     DatasetsProcessesMixin,
+    CategoriesMixin,
     law.LocalWorkflow,
+    ProducersMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
     RemoteWorkflow,
 ):
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
@@ -31,6 +38,12 @@ class CreateYieldTable(
         description="format of the yield table, takes all fromats taken by the tabulate package; default: latex_raw",
     )
 
+    skip_variance = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="wether to skip variance or not; default: False",
+    )
+
     # dummy branch map
     def create_branch_map(self):
         return [0]
@@ -40,7 +53,7 @@ class CreateYieldTable(
             d: self.dep_MergeHistograms.req(
                 self,
                 dataset=d,
-                variables=("mc_weight",),
+                variables=("event",),
                 _prefer_cli={"variables"},
             )
             for d in self.datasets
@@ -54,6 +67,7 @@ class CreateYieldTable(
         import hist
         from tabulate import tabulate
 
+        category_insts = list(map(self.config_inst.get_category, self.categories))
         process_insts = list(map(self.config_inst.get_process, self.processes))
         sub_process_insts = {
             proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
@@ -63,10 +77,10 @@ class CreateYieldTable(
         # histogram data per process
         hists = {}
 
-        with self.publish_step("dummy text"):
+        with self.publish_step(f"Creating yields for processes {self.processes}, categories {self.categories}"):
             for dataset, inp in self.input().items():
                 dataset_inst = self.config_inst.get_dataset(dataset)
-                h_in = inp["mc_weight"].load(formatter="pickle")
+                h_in = inp["event"].load(formatter="pickle")
 
                 # loop and extract one histogram per process
                 for process_inst in process_insts:
@@ -87,7 +101,7 @@ class CreateYieldTable(
                     }]
 
                     # axis reductions
-                    h = h[{"process": sum, "shift": sum, "mc_weight": sum}]
+                    h = h[{"process": sum, "shift": sum, "event": sum}]
 
                     # add the histogram
                     if process_inst in hists:
@@ -106,24 +120,35 @@ class CreateYieldTable(
             )
 
             yields = []
-            yield_header = ["Process"]
+            yield_header = ["Process"] + [category_inst.label for category_inst in category_insts]
+
+
 
             for process_inst, h in hists.items():
                 row = []
                 row.append(process_inst.label)
 
-                for i in range(h.axes["category"].size):
-                    if len(yield_header) <= h.axes["category"].size:
-                        yield_header.append(self.config_inst.get_category(h.axes["category"].bin(i)).label)
-                    row.append(f"{round(h[i].value)} $\pm$ {round(h[i].variance)}")
+                for category_inst in category_insts:
+                    leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
+
+                    h_cat = h[{"category": [
+                        hist.loc(c.id)
+                        for c in leaf_category_insts
+                        if c.id in h.axes["category"]
+                    ]}]
+                    h_cat = h_cat[{"category": sum}]
+
+                    value = h_cat.value
+                    variance = h_cat.variance
+                    # TODO: rounding should be less arbitrary, e.g. always round to 4 significant
+                    row.append(
+                        f"{value:.1f}" if self.skip_variance else
+                        rf"${value:.1f} \pm {variance:.1f}$"
+                    )
 
                 yields.append(row)
 
             yield_table = tabulate(yields, headers=yield_header, tablefmt=self.table_format)
+            print(yield_table)
 
-            # TODO: create some output using something like
-            #
-            # self.output().dump(yield_table, formatter="txt")
-
-            with open(self.output().fn, "w") as f:
-                f.write(yield_table)
+            self.output().dump(yield_table)

--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -57,10 +57,10 @@ class CreateYieldTable(
         ),
     )
 
-    skip_variance = luigi.BoolParameter(
+    skip_uncert = luigi.BoolParameter(
         default=False,
         significant=False,
-        description="when True, variances are not displayed in the table; default: False",
+        description="when True, uncertainties are not displayed in the table; default: False",
     )
 
     # dummy branch map
@@ -94,7 +94,7 @@ class CreateYieldTable(
         return reqs
 
     def output(self):
-        return self.target("yields.txt")
+        return self.target(f"yields__proc_{self.processes_repr}__cat_{self.categories_repr}.txt")
 
     @law.decorator.log
     def run(self):
@@ -173,7 +173,7 @@ class CreateYieldTable(
                     value = Number(h_cat.value, math.sqrt(h_cat.variance))
 
                     # TODO: allow normalizing per process or per category (or both?)
-                    if self.skip_variance:
+                    if self.skip_uncert:
                         value_str = value.str(format=self.number_format).split(" +- ")[0]
                     else:
                         value_str = value.str(

--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -7,6 +7,7 @@ Tasks to produce yield tables
 from collections import OrderedDict
 
 import law
+import luigi
 
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
@@ -23,6 +24,12 @@ class CreateYieldTable(
     sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
 
     dep_MergeHistograms = MergeHistograms
+
+    table_format = luigi.Parameter(
+        default="latex_raw",
+        significant=False,
+        description="format of the yield table, takes all fromats taken by the tabulate package; default: latex_raw",
+    )
 
     # dummy branch map
     def create_branch_map(self):
@@ -112,7 +119,7 @@ class CreateYieldTable(
 
                 yields.append(row)
 
-            yield_table = tabulate(yields, headers=yield_header, tablefmt="latex_raw")
+            yield_table = tabulate(yields, headers=yield_header, tablefmt=self.table_format)
 
             # TODO: create some output using something like
             #

--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+
+"""
+Tasks to produce yield tables
+"""
+
+from collections import OrderedDict
+
+import law
+
+from columnflow.tasks.framework.mixins import DatasetProcessesMixin
+from columnflow.tasks.framework.remote import RemoteWorkflow
+
+from columnflow.tasks.histograms import MergeHistograms
+from colummnflow.util import dev_sandbox
+
+
+class CreateYieldTable(
+    DatasetProcessesMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
+
+    dep_MergeHistograms = MergeHistograms
+
+    def requires(self):
+        return {
+            d: self.dep_MergeHistograms.req(
+                self,
+                dataset=d,
+                variables=("mc_weight",),
+                _prefer_cli={"variables"},
+            )
+            for d in self.datasets
+        }
+
+    def output(self):
+        return self.target("yields.txt")
+
+    @law.decorator.log
+    def run(self):
+        import hist
+
+        process_insts = list(map(self.config_inst.get_process, self.processes))
+        sub_process_insts = {
+            proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
+            for proc in process_insts
+        }
+
+        # histogram data per process
+        hists = {}
+
+        with self.publish_step("dummy text"):
+            for dataset, inp in self.input().items():
+                dataset_inst = self.config_inst.get_dataset(dataset)
+                # TODO: get correct input
+                h_in = inp["collection"][0].load(formatter="pickle")
+
+                # loop and extract one histogram per process
+                for process_inst in process_insts:
+                    # skip when the dataset is already known to not contain any sub process
+                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                        continue
+
+                    # work on a copy
+                    h = h_in.copy()
+
+                    # axis selections
+                    h = h[{
+                        "process": [
+                            hist.loc(p.id)
+                            for p in sub_process_insts[process_inst]
+                            if p.id in h.axes["process"]
+                        ],
+                    }]
+
+                    # axis reductions
+                    h = h[{"process": sum, "category": sum, "shift": sum}]
+
+                    # add the histogram
+                    if process_inst in hists:
+                        hists[process_inst] += h
+                    else:
+                        hists[process_inst] = h
+
+            # there should be hists to plot
+            if not hists:
+                raise Exception("no histograms found to plot")
+
+            # sort hists by process order
+            hists = OrderedDict(
+                (process_inst, hists[process_inst])
+                for process_inst in sorted(hists, key=process_insts.index)
+            )
+
+            # TODO: create some output
+
+            # save the output (TODO)
+            # outp.dump(fig, formatter="txt")

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -10,7 +10,7 @@ __all__ = [
     "UNSET", "env_is_remote", "env_is_dev", "primes",
     "maybe_import", "import_plt", "import_ROOT", "import_file", "create_random_name", "expand_path",
     "real_path", "ensure_dir", "wget", "call_thread", "call_proc", "ensure_proxy", "dev_sandbox",
-    "safe_div", "test_float", "is_pattern", "is_regex", "pattern_matcher",
+    "safe_div", "test_float", "test_int", "is_pattern", "is_regex", "pattern_matcher",
     "dict_add_strict", "get_source_code",
     "DotDict", "MockModule", "FunctionArgs", "ClassPropertyDescriptor", "classproperty",
     "DerivableMeta", "Derivable",
@@ -394,10 +394,21 @@ def safe_div(a: int | float, b: int | float) -> float:
 
 def test_float(f: Any) -> bool:
     """
-    Tests whether a value *i* can be converted to a float.
+    Tests whether a value *f* can be converted to a float.
     """
     try:
         float(f)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def test_int(i: Any) -> bool:
+    """
+    Tests whether a value *i* can be converted to an integer.
+    """
+    try:
+        int(i)
         return True
     except (ValueError, TypeError):
         return False

--- a/law.cfg
+++ b/law.cfg
@@ -10,6 +10,7 @@ columnflow.tasks.ml
 columnflow.tasks.union
 columnflow.tasks.histograms
 columnflow.tasks.plotting
+columnflow.tasks.yields
 columnflow.tasks.cutflow
 
 

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,6 +1,6 @@
 # version 8
 
 luigi==3.2.*
-scinum>=1.4.3
+scinum>=1.4.6
 six==1.16.*
 pyyaml==6.*


### PR DESCRIPTION
Example task:
```
law run cf.CreateYieldTable --version v1 --processes tt_sl,st_tchannel_t --categories incl,1mu
```
Parameters that are already implemented are `table_format` (changing the tabulate table style), `number_format` (changing the scinum.number string format) and `skip_uncert` (to not display the uncertainties in the table).

An option to normalise entries in the table is still missing.