### PR TITLE
Add category id creation to config_util.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -14,7 +14,7 @@ from scinum import Number
 from columnflow.util import DotDict
 from columnflow.columnar_util import EMPTY_FLOAT
 from columnflow.config_util import (
-    get_root_processes_from_campaign, add_shift_aliases, get_shifts_from_sources,
+    get_root_processes_from_campaign, add_shift_aliases, get_shifts_from_sources, add_category,
 )
 
 
@@ -244,17 +244,17 @@ cfg.x.versions = {
 # (just one for now)
 cfg.add_channel(name="mutau", id=1)
 
-# add categories
+# add categories using the "add_category" tool which adds auto-generated ids
 # the "selection" entries refer to names of selectors, e.g. in selection/example.py
-cfg.add_category(
+add_category(
+    cfg,
     name="incl",
-    id=1,
     selection="sel_incl",
     label="inclusive",
 )
-cfg.add_category(
+add_category(
+    cfg,
     name="2j",
-    id=2,
     selection="sel_2j",
     label="2 jets",
 )

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 __all__ = [
     "get_root_processes_from_campaign", "add_shift_aliases", "get_shifts_from_sources",
-    "create_category_combinations",
+    "create_category_id", "add_category", "create_category_combinations",
 ]
 
 import re
 import itertools
 from typing import Callable, Any
 
+import law
 import order as od
 
 
@@ -83,6 +84,36 @@ def get_shifts_from_sources(config: od.Config, *shift_sources: str) -> list[od.S
     )
 
 
+def create_category_id(
+    config: od.Config,
+    category_name: str,
+    hash_len: int = 7,
+) -> int:
+    """
+    Creates a unique id for a :py:class:`order.Category` named *category_name* in a
+    :py:class:`order.Config` object *config* and returns it. Internally,
+    :py:func:`law.util.create_hash` is used which receives *hash_len*.
+    """
+    h = law.util.create_hash((config.name, config.id, category_name), l=hash_len)
+    return int(h, base=16)
+
+
+def add_category(config: od.Config, **kwargs) -> od.Category:
+    """
+    Creates a :py:class:`order.Category` instance by forwarding all *kwargs* to its constructor,
+    adds it to a :py:class:`order.Config` object *config* and returns it. When *kwargs* do not
+    contain a field *id*, :py:func:`create_category_id` is used to create one.
+    """
+    if "name" not in kwargs:
+        fields = ",".join(map(str, kwargs))
+        raise ValueError(f"a field 'name' is required to create a category, got '{fields}'")
+
+    if "id" not in kwargs:
+        kwargs["id"] = create_category_id(config, kwargs["name"])
+
+    return config.add_category(**kwargs)
+
+
 def create_category_combinations(
     config: od.Config,
     categories: dict[str, list[od.Categories]],
@@ -103,11 +134,11 @@ def create_category_combinations(
     arguments as returned by *kwargs_fn*. This function is called with the categories (in a
     dictionary, mapped to the sequence names as given in *categories*) that contribute to the newly
     created category and should return a dictionary. If the fields ``"id"`` and ``"selection"`` are
-    missing, they are filled with reasonable defaults leading to an auto-incremented id and a list
-    of all parent selection statements.
+    missing, they are filled with reasonable defaults leading to a auto-generated, deterministic id
+    and a list of all parent selection statements.
 
-    If the name of a new category is already known to *config* it skipped unless *skip_existing* is
-    *False*.
+    If the name of a new category is already known to *config* it is skipped unless *skip_existing*
+    is *False*.
 
     Example:
 
@@ -168,8 +199,10 @@ def create_category_combinations(
 
                 # create arguments for the new category
                 kwargs = kwargs_fn(root_cats) if callable(kwargs_fn) else {}
-                kwargs.setdefault("id", "+")
-                kwargs.setdefault("selection", [c.selection for c in root_cats.values()])
+                if "id" not in kwargs:
+                    kwargs["id"] = create_category_id(config, cat_name)
+                if "selection" not in kwargs:
+                    kwargs["selection"] = [c.selection for c in root_cats.values()]
 
                 # create the new category
                 cat = od.Category(name=cat_name, **kwargs)


### PR DESCRIPTION
This PR adds a small config_util to auto-generate deterministic category ids.

They are ensured to remain unique within the config they are added to using a hash created from config id, config name and category name.

Closes #192.