### PR TITLE
enabled handling of just eight LHEScaleWeights

### DIFF
--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -177,7 +177,7 @@ def murmuf_envelope_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Ar
     n_weights = ak.num(events.LHEScaleWeight, axis=1)
 
     if ak.all(n_weights == 9):
-        murf_nominal = events.LHEScaleWeight[:, 4]
+        murf_nominal = events.LHEScaleWeight[:, self.indices_9.mur_nom_muf_nom]
         envelope_indices = self.envelope_indices_9
 
         # perform an additional check to see of the nominal value is ever != 1
@@ -220,7 +220,7 @@ def murmuf_envelope_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Ar
 @murmuf_envelope_weights.setup
 def murmuf_envelope_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
     # define the indices of weights to consider for the envelope construction
-    all_indices_9 = DotDict(
+    self.indices_9 = DotDict(
         mur_down_muf_down=0,
         mur_down_muf_nom=1,
         mur_down_muf_up=2,
@@ -235,7 +235,7 @@ def murmuf_envelope_weights_setup(self: Producer, reqs: dict, inputs: dict) -> N
     # create a flat list if indices, skipping those for crossed variations
     self.envelope_indices_9 = [
         index
-        for name, index in all_indices_9.items()
+        for name, index in self.indices_9.items()
         if name not in ["mur_down_muf_up", "mur_up_muf_down"]
     ]
 
@@ -243,6 +243,6 @@ def murmuf_envelope_weights_setup(self: Producer, reqs: dict, inputs: dict) -> N
     # is missing and the entries above are shifted down by one
     self.envelope_indices_8 = [
         index if index <= 4 else index - 1
-        for name, index in all_indices_9.items()
+        for name, index in self.indices_9.items()
         if name not in ["mur_down_muf_up", "mur_up_muf_down", "mur_nom_muf_nom"]
     ]

--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -63,6 +63,11 @@ def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         # instead, initialize the nominal weights as ones.
         # Additionally, we need to shift the last couple of weight indices
         # down by 1
+        logger.debug(
+            f"In dataset {self.dataset_inst.name}: number of LHEScaleWeights is always " +
+            "8 instead of the expected 9. It is assumed, that the missing entry is the " +
+            "nominal one and all other entries are in correct order",
+        )
         murf_nominal = ak.ones_like(events.event)
         mur_nom_muf_up -= 1
         mur_up_muf_down -= 1


### PR DESCRIPTION
The current version of the cms LHEScaleWeight producer only allows for exactly 9 weights per event. However, there are also (some) samples that only provide 8 weights (nominal weight is dropped). This leads to a break down of the murf_scale weight producer.

This small PR extends the functionality to also handle samples with only 8 LHE weights. The producer now checks for either 9 or 8 weights. If there are only 8 LHE weights, the indices for the LHE weights that are "normally" behind the nominal weight (i.e. anything after index `4`) are shifted by one to correct the mapping to the corresponding variations.

Side note: The current documentation of NanoAOD v11 does not provide anything about the order of the LHEScaleWeights. Indeed, in the [latest](https://cms-nanoaod-integration.web.cern.ch/autoDoc/NanoAODv11/2022postEE/doc_WZ_TuneCP5_13p6TeV_pythia8_Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1.html) version of the documentation, the LHEScaleWeight branch is completely missing from the list of available branches. Might be worthwhile to keep an eye on this.