### PR TITLE
change task outputs to dictionaries for calibration/selection/reduction

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/ml/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/ml/example.py
@@ -65,7 +65,7 @@ class ExampleModel(MLModel):
     def train(
         self,
         task: law.Task,
-        input: dict[str, list[law.FileSystemFileTarget]],
+        input: dict[str, list[dict[str, law.FileSystemFileTarget]]],
         output: law.FileSystemDirectoryTarget,
     ) -> None:
         # define a dummy NN

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -79,7 +79,7 @@ def normalization_weights_setup(self: Producer, reqs: dict, inputs: dict) -> Non
           processes known to the config of the task, with keys being process ids.
     """
     # load the selection stats
-    selection_stats = inputs["selection_stats"]["collection"][0].load(formatter="json")
+    selection_stats = inputs["selection_stats"]["collection"][0]["stats"].load(formatter="json")
 
     # for the lookup tables below, determine the maximum process id
     process_insts = [

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -53,7 +53,7 @@ class CalibrateEvents(
         return reqs
 
     def output(self):
-        return {"calibration": self.target(f"calib_{self.branch}.parquet")}
+        return {"columns": self.target(f"calib_{self.branch}.parquet")}
 
     @law.decorator.log
     @ensure_proxy
@@ -115,7 +115,7 @@ class CalibrateEvents(
             self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge output files
-        with output["calibration"].localize("w") as outp:
+        with output["columns"].localize("w") as outp:
             sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
             law.pyarrow.merge_parquet_task(self, sorted_chunks, outp, local=True)
 

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -53,7 +53,7 @@ class CalibrateEvents(
         return reqs
 
     def output(self):
-        return self.target(f"calib_{self.branch}.parquet")
+        return {"calibration": self.target(f"calib_{self.branch}.parquet")}
 
     @law.decorator.log
     @ensure_proxy
@@ -115,7 +115,7 @@ class CalibrateEvents(
             self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
 
         # merge output files
-        with output.localize("w") as outp:
+        with output["calibration"].localize("w") as outp:
             sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
             law.pyarrow.merge_parquet_task(self, sorted_chunks, outp, local=True)
 

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -134,7 +134,7 @@ class CreateDatacards(
                         continue
 
                     # open the histogram and work on a copy
-                    h = _inp["collection"][0][variable_inst.name].load(formatter="pickle").copy()
+                    h = _inp["collection"][0]["hists"][variable_inst.name].load(formatter="pickle").copy()
 
                     # axis selections
                     h = h[{

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -142,7 +142,7 @@ class CreateCutflowHistograms(
                     histograms[var_key] = h.Weight()
 
         for arr, pos in self.iter_chunked_io(
-            inputs["masks"].path,
+            inputs["masks"]["masks"].path,
             source_type="awkward_parquet",
             read_columns=load_columns,
         ):
@@ -298,10 +298,10 @@ class PlotCutflow(
         }
 
     def output(self):
-        return [
+        return {"plots": [
             self.target(name)
             for name in self.get_plot_names(f"cutflow__cat_{self.branch_data}")
-        ]
+        ]}
 
     @law.decorator.log
     @view_output_plots
@@ -382,7 +382,7 @@ class PlotCutflow(
             )
 
             # save the plot
-            for outp in self.output():
+            for outp in self.output()["plots"]:
                 outp.dump(fig, formatter="mpl")
 
 
@@ -569,22 +569,22 @@ class PlotCutflowVariables1D(
     def output(self):
         b = self.branch_data
         if self.per_plot == "processes":
-            return law.SiblingFileCollection({
+            return {"plots": law.SiblingFileCollection({
                 s: [
                     self.local_target(name) for name in self.get_plot_names(
                         f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
                     )
                 ]
                 for i, s in enumerate(self.chosen_steps)
-            })
+            })}
         else:  # per_plot == "steps"
-            return law.SiblingFileCollection({
+            return {"plots": law.SiblingFileCollection({
                 p: [
                     self.local_target(name)
                     for name in self.get_plot_names(f"plot__proc_{p}__cat_{b.category}__var_{b.variable}")
                 ]
                 for p in self.processes
-            })
+            })}
 
     def run_postprocess(self, hists, category_inst, variable_insts):
         import hist
@@ -592,7 +592,7 @@ class PlotCutflowVariables1D(
         if len(variable_insts) != 1:
             raise Exception(f"task {self.task_family} is only viable for single variables")
 
-        outputs = self.output()
+        outputs = self.output()["plots"]
         if self.per_plot == "processes":
             for step in self.chosen_steps:
                 step_hists = OrderedDict(
@@ -649,19 +649,19 @@ class PlotCutflowVariables2D(
 
     def output(self):
         b = self.branch_data
-        return law.SiblingFileCollection({
+        return {"plots": law.SiblingFileCollection({
             s: [
                 self.local_target(name) for name in self.get_plot_names(
                     f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
                 )
             ]
             for i, s in enumerate(self.chosen_steps)
-        })
+        })}
 
     def run_postprocess(self, hists, category_inst, variable_insts):
         import hist
 
-        outputs = self.output()
+        outputs = self.output()["plots"]
 
         for step in self.chosen_steps:
             step_hists = OrderedDict(

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -56,13 +56,13 @@ class CreateCutflowHistograms(
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        reqs["masks"] = self.reqs.MergeSelectionMasks.req(self, tree_index=0, _exclude={"branches"})
+        reqs["selection"] = self.reqs.MergeSelectionMasks.req(self, tree_index=0, _exclude={"branches"})
 
         return reqs
 
     def requires(self):
         return {
-            "masks": self.reqs.MergeSelectionMasks.req(self, tree_index=0, branch=0),
+            "selection": self.reqs.MergeSelectionMasks.req(self, tree_index=0, branch=0),
         }
 
     def output(self):
@@ -142,7 +142,7 @@ class CreateCutflowHistograms(
                     histograms[var_key] = h.Weight()
 
         for arr, pos in self.iter_chunked_io(
-            inputs["masks"]["masks"].path,
+            inputs["selection"]["masks"].path,
             source_type="awkward_parquet",
             read_columns=load_columns,
         ):

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -132,7 +132,7 @@ class CreateHistograms(
         if self.producers:
             files.extend([inp["columns"].path for inp in inputs["producers"]])
         if self.ml_models:
-            files.extend([inp.path for inp in inputs["ml"]])
+            files.extend([inp["mlcols"].path for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -132,7 +132,7 @@ class CreateHistograms(
         if self.producers:
             files.extend([inp["columns"].path for inp in inputs["producers"]])
         if self.ml_models:
-            files.extend([inp["mlcols"].path for inp in inputs["ml"]])
+            files.extend([inp["mlcolumns"].path for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -462,7 +462,7 @@ class MLEvaluation(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return {"mlcols": self.target(f"mlcols_{self.branch}.pickle")}
+        return {"mlcolumns": self.target(f"mlcolumns_{self.branch}.pickle")}
 
     @law.decorator.log
     @law.decorator.localize
@@ -547,7 +547,7 @@ class MLEvaluation(
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
-        law.pyarrow.merge_parquet_task(self, sorted_chunks, output["mlcols"], local=True)
+        law.pyarrow.merge_parquet_task(self, sorted_chunks, output["mlcolumns"], local=True)
 
 
 # overwrite class defaults

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -96,7 +96,7 @@ class PlotVariablesBase(
         with self.publish_step(f"plotting {self.branch_data.variable} in {category_inst.name}"):
             for dataset, inp in self.input().items():
                 dataset_inst = self.config_inst.get_dataset(dataset)
-                h_in = inp["collection"][0].targets[self.branch_data.variable].load(formatter="pickle")
+                h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
 
                 # loop and extract one histogram per process
                 for process_inst in process_insts:
@@ -160,7 +160,7 @@ class PlotVariablesBase(
             )
 
             # save the plot
-            for outp in self.output():
+            for outp in self.output()["plots"]:
                 outp.dump(fig, formatter="mpl")
 
 
@@ -197,10 +197,10 @@ class PlotVariablesBaseSingleShift(
 
     def output(self):
         b = self.branch_data
-        return [
+        return {"plots": [
             self.target(name)
             for name in self.get_plot_names(f"plot__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}")
-        ]
+        ]}
 
     def get_plot_shifts(self):
         return [self.global_shift_inst]
@@ -281,12 +281,12 @@ class PlotVariablesBaseMultiShifts(
 
     def output(self):
         b = self.branch_data
-        return [
+        return {"plots": [
             self.target(name)
             for name in self.get_plot_names(
                 f"plot__proc_{self.processes_repr}__unc_{b.shift_source}__cat_{b.category}__var_{b.variable}",
             )
-        ]
+        ]}
 
     def get_plot_shifts(self):
         return [

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -55,7 +55,7 @@ class ProduceColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return self.target(f"columns_{self.branch}.parquet")
+        return {"columns": self.target(f"columns_{self.branch}.parquet")}
 
     @law.decorator.log
     @law.decorator.localize
@@ -91,7 +91,7 @@ class ProduceColumns(
 
         # iterate over chunks of events and diffs
         for events, pos in self.iter_chunked_io(
-            inputs["events"]["collection"][0].path,
+            inputs["events"]["collection"][0]["events"].path,
             source_type="awkward_parquet",
             read_columns=read_columns,
         ):
@@ -116,7 +116,7 @@ class ProduceColumns(
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
-        law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+        law.pyarrow.merge_parquet_task(self, sorted_chunks, output["columns"], local=True)
 
 
 # overwrite class defaults

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -150,7 +150,7 @@ class ReduceEvents(
         # collect input paths
         input_paths = [nano_file]
         input_paths.append(inputs["selection"]["results"].path)
-        input_paths.extend([inp["calibration"].path for inp in inputs["calibrations"]])
+        input_paths.extend([inp["columns"].path for inp in inputs["calibrations"]])
         if self.selector_inst.produced_columns:
             input_paths.append(inputs["selection"]["columns"].path)
 

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -134,7 +134,7 @@ class SelectEvents(
         # iterate over chunks of events and diffs
         n_calib = len(inputs["calibrations"])
         for (events, *diffs), pos in self.iter_chunked_io(
-            [nano_file] + [inp["calibration"].path for inp in inputs["calibrations"]],
+            [nano_file] + [inp["columns"].path for inp in inputs["calibrations"]],
             source_type=["coffea_root"] + n_calib * ["awkward_parquet"],
             read_columns=(1 + n_calib) * [read_columns],
         ):

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -134,7 +134,7 @@ class SelectEvents(
         # iterate over chunks of events and diffs
         n_calib = len(inputs["calibrations"])
         for (events, *diffs), pos in self.iter_chunked_io(
-            [nano_file] + [inp.path for inp in inputs["calibrations"]],
+            [nano_file] + [inp["calibration"].path for inp in inputs["calibrations"]],
             source_type=["coffea_root"] + n_calib * ["awkward_parquet"],
             read_columns=(1 + n_calib) * [read_columns],
         ):

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -246,7 +246,7 @@ class MergeSelectionStats(
         )
 
     def merge_output(self):
-        return self.target("stats.json")
+        return {"stats": self.target("stats.json")}
 
     def trace_merge_inputs(self, inputs):
         return super().trace_merge_inputs(
@@ -265,7 +265,7 @@ class MergeSelectionStats(
             self.merge_counts(merged_stats, stats)
 
         # write the output
-        output.dump(merged_stats, indent=4, formatter="json", cache=False)
+        output["stats"].dump(merged_stats, indent=4, formatter="json", cache=False)
 
     @classmethod
     def merge_counts(cls, dst: dict, src: dict) -> dict:
@@ -352,7 +352,7 @@ class MergeSelectionMasks(
         return super().trace_merge_inputs(inputs["selection"])
 
     def merge_output(self):
-        return self.target("masks.parquet")
+        return {"masks": self.target("masks.parquet")}
 
     def merge(self, inputs, output):
         # in the lowest (leaf) stage, zip selection results with additional columns first
@@ -362,7 +362,7 @@ class MergeSelectionMasks(
             tmp_dir.touch()
             inputs = self.zip_results_and_columns(inputs, tmp_dir)
 
-        law.pyarrow.merge_parquet_task(self, inputs, output)
+        law.pyarrow.merge_parquet_task(self, inputs, output["masks"])
 
     def zip_results_and_columns(self, inputs, tmp_dir):
         from columnflow.columnar_util import RouteFilter, sorted_ak_to_parquet, mandatory_coffea_columns

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -78,7 +78,7 @@ class UniteColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return self.target(f"data_{self.branch}.parquet")
+        return {"columns": self.target(f"data_{self.branch}.parquet")}
 
     @law.decorator.log
     @law.decorator.localize(input=True, output=False)
@@ -106,9 +106,9 @@ class UniteColumns(
         read_columns = {Route(c) for c in read_columns}
 
         # iterate over chunks of events and diffs
-        files = [inputs["events"]["collection"][0].path]
+        files = [inputs["events"]["collection"][0]["events"].path]
         if self.producers:
-            files.extend([inp.path for inp in inputs["producers"]])
+            files.extend([inp["columns"].path for inp in inputs["producers"]])
         if self.ml_models:
             files.extend([inp.path for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
@@ -133,7 +133,7 @@ class UniteColumns(
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
-        law.pyarrow.merge_parquet_task(self, sorted_chunks, output, local=True)
+        law.pyarrow.merge_parquet_task(self, sorted_chunks, output["columns"], local=True)
 
 
 # overwrite class defaults

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -110,7 +110,7 @@ class UniteColumns(
         if self.producers:
             files.extend([inp["columns"].path for inp in inputs["producers"]])
         if self.ml_models:
-            files.extend([inp["mlcols"].path for inp in inputs["ml"]])
+            files.extend([inp["mlcolumns"].path for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -110,7 +110,7 @@ class UniteColumns(
         if self.producers:
             files.extend([inp["columns"].path for inp in inputs["producers"]])
         if self.ml_models:
-            files.extend([inp.path for inp in inputs["ml"]])
+            files.extend([inp["mlcols"].path for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],


### PR DESCRIPTION
As mentioned in #223, it might be nice to always return dictionaries as task outputs.
I implemented these changes for all tasks except external tasks (CreatePileupWeights, GetDatasetLFNS, etc.).

From the user side, there might be changes required in some producers that require tasks on their own (e.g. stats in weight renormalisation producers) and in the ML Model