### PR TITLE
fix attachment of coffea behaviors

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -42,6 +42,7 @@ uproot = maybe_import("uproot")
 coffea = maybe_import("coffea")
 maybe_import("coffea.nanoevents")
 maybe_import("coffea.nanoevents.methods.base")
+coffea_nanoaod = maybe_import("coffea.nanoevents.methods.nanoaod")
 pq = maybe_import("pyarrow.parquet")
 
 logger = law.logger.get_logger(__name__)
@@ -993,8 +994,9 @@ def attach_behavior(
     By default, all subfields of *ak_array* are kept. For further control, *skip_fields* can contain
     names or name patterns of fields that are filtered.
     """
+
     if behavior is None:
-        behavior = getattr(ak_array, "behavior", None)
+        behavior = getattr(ak_array, "behavior") or coffea_nanoaod.behavior
         if behavior is None:
             raise ValueError(
                 f"behavior for type '{type_name}' is not set and not existing in input array",


### PR DESCRIPTION
For many analyses, the usage of four momenta for the calculation of variables/observables is critical. columnflow utilizes awkward array behaviors from `coffea`, which provide some very nice convenience functions (e.g. `metric_table` and `sum`) and also include the definition of operators like `+` etc. for four momenta.

In the current version of cf, this mechanism is broken in any step after the `ReduceEvents` task. It seems like the awkward arrays loose their intrinsic behavior somewhere along the way, which leads to a crash in `columnar_util.attach_behavior`.

This PR restores the behavior by providing the original `coffea` nanoaod behavior as an alternative in case the current awkward array does not have a behavior already. This fix is quite minimal, but restores full functionality for four momenta (tested with `Jet` collection).

Side note: Is there still a reason that the coffea version in the `columnar.txt` requirement is fixed to a private fork of `coffea`? I've had a (very brief) look through the history of the `awkward_v2_dev` branch of `coffea` and had the impression that the fix was already included there. 